### PR TITLE
Handle semicolon-separated ESR spectra

### DIFF
--- a/esr_lab/io.py
+++ b/esr_lab/io.py
@@ -15,6 +15,11 @@ class ESRLoader:
     def load_csv(path: Union[str, Path]) -> ESRSpectrum:
         """Load a spectrum from a CSV file.
 
+        The loader automatically detects whether values are separated by
+        commas or semicolons.  Only the first two columns are used and they are
+        renamed to ``"BField [mT]"`` for the magnetic field and
+        ``"MW_Absorption []"`` for the intensity.
+
         Parameters
         ----------
         path:
@@ -23,5 +28,22 @@ class ESRLoader:
         """
 
         path = Path(path)
-        df = pd.read_csv(path)
+
+        # ``sep=None`` together with the python engine lets pandas sniff the
+        # delimiter, allowing us to support both comma and semicolon separated
+        # data.  This is important because some spectrometers export data using
+        # semicolons which previously resulted in a single-column DataFrame and
+        # downstream ``IndexError`` when accessing the intensity column.
+        df = pd.read_csv(path, sep=None, engine="python")
+
+        # Ensure we have at least two columns for field and intensity.
+        if df.shape[1] < 2:
+            raise ValueError(
+                "CSV file must contain at least two columns for field and intensity"
+            )
+
+        # Use only the first two columns and give them standard names.
+        df = df.iloc[:, :2].copy()
+        df.columns = ["BField [mT]", "MW_Absorption []"]
+
         return ESRSpectrum.from_dataframe(df)


### PR DESCRIPTION
## Summary
- Support comma or semicolon separated ESR data in loader
- Standardize column names to `BField [mT]` and `MW_Absorption []`

## Testing
- `python - <<'PY'
from pathlib import Path
from esr_lab.io import ESRLoader

tmp = Path('data/tmp_semicolon.csv')
tmp.write_text('BField [mT];MW_Absorption []\n1;2\n3;4\n')

spec = ESRLoader.load_csv(tmp)
print(spec.field)
print(spec.intensity)

tmp.unlink()
PY`
- `python - <<'PY'
from esr_lab.io import ESRLoader
spec = ESRLoader.load_csv('data/example_esr.csv')
print(len(spec.field), len(spec.intensity))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac7c35002883249cdb327255ed1e15