### PR TITLE
Simplify plotter to display spectrum

### DIFF
--- a/esr_lab/app.py
+++ b/esr_lab/app.py
@@ -8,18 +8,15 @@ from .plotter import ESRPlotter
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Visualize ESR spectra from CSV files")
-    parser.add_argument("file", type=Path, help="Path to a CSV ESR file")
-    parser.add_argument(
-        "--save",
-        type=Path,
-        help="Path to save the generated plot instead of displaying it",
+    parser = argparse.ArgumentParser(
+        description="Visualize ESR spectra from CSV files"
     )
+    parser.add_argument("file", type=Path, help="Path to a CSV ESR file")
     args = parser.parse_args()
 
     spectrum = ESRLoader.load_csv(args.file)
     plotter = ESRPlotter()
-    plotter.plot(spectrum, show=args.save is None, save=str(args.save) if args.save else None)
+    plotter.plot(spectrum)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/esr_lab/plotter.py
+++ b/esr_lab/plotter.py
@@ -1,7 +1,5 @@
 """Plotting utilities for ESR spectra."""
 
-import matplotlib
-matplotlib.use("Agg")  # Use a non-interactive backend suitable for scripts
 import matplotlib.pyplot as plt
 
 from .spectrum import ESRSpectrum
@@ -10,28 +8,18 @@ from .spectrum import ESRSpectrum
 class ESRPlotter:
     """Plotter for ESR spectra."""
 
-    def __init__(self) -> None:
-        self._fig, self._ax = plt.subplots()
-
-    def plot(self, spectrum: ESRSpectrum, *, show: bool = True, save: str | None = None) -> None:
+    def plot(self, spectrum: ESRSpectrum) -> None:
         """Plot the provided spectrum.
 
         Parameters
         ----------
         spectrum:
             The spectrum to plot.
-        show:
-            Whether to display the plot in an interactive window.
-        save:
-            Optional path to save the figure to instead of displaying it.
         """
 
-        self._ax.plot(spectrum.field, spectrum.intensity)
-        self._ax.set_xlabel("Magnetic Field")
-        self._ax.set_ylabel("Intensity")
-        self._ax.set_title("ESR Spectrum")
-
-        if save:
-            self._fig.savefig(save)
-        if show:
-            plt.show()
+        fig, ax = plt.subplots()
+        ax.plot(spectrum.field, spectrum.intensity)
+        ax.set_xlabel("Magnetic Field")
+        ax.set_ylabel("Intensity")
+        ax.set_title("ESR Spectrum")
+        plt.show()


### PR DESCRIPTION
## Summary
- Remove save/show logic from `ESRPlotter` so it just plots the spectrum and displays it
- Drop `--save` option from CLI app and invoke the plotter directly

## Testing
- `python -m py_compile esr_lab/plotter.py esr_lab/app.py`
- `pytest`
- `MPLBACKEND=Agg python -m esr_lab.app data/example_esr.csv`


------
https://chatgpt.com/codex/tasks/task_e_68ac7d9439fc8324a13549afb9b20a67