### PR TITLE
Add comprehensive tests for ESR modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on the Python path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,15 @@
+import sys
+from unittest.mock import patch
+
+from esr_lab import app
+
+
+def test_main_runs(tmp_path, monkeypatch):
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("a,b\n1,2\n")
+
+    monkeypatch.setattr(sys, "argv", ["prog", str(csv_file)])
+
+    with patch("esr_lab.app.ESRPlotter.plot") as plot_mock:
+        app.main()
+        plot_mock.assert_called_once()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+from esr_lab import gui
+
+
+def test_gui_main(monkeypatch, tmp_path):
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("a,b\n1,2\n")
+
+    class DummyTk:
+        def withdraw(self):
+            pass
+
+    monkeypatch.setattr(gui.tk, "Tk", lambda: DummyTk())
+    monkeypatch.setattr(gui.filedialog, "askopenfilename", lambda **kwargs: str(csv_file))
+
+    with patch("esr_lab.gui.ESRPlotter.plot") as plot_mock:
+        gui.main()
+        plot_mock.assert_called_once()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,19 @@
+from esr_lab.io import ESRLoader
+
+
+def test_load_csv_comma(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("a,b\n1,2\n")
+
+    spectrum = ESRLoader.load_csv(csv_file)
+    assert spectrum.field.tolist() == [1]
+    assert spectrum.intensity.tolist() == [2]
+
+
+def test_load_csv_semicolon(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("a;b\n3;4\n")
+
+    spectrum = ESRLoader.load_csv(csv_file)
+    assert spectrum.field.tolist() == [3]
+    assert spectrum.intensity.tolist() == [4]

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1,0 +1,16 @@
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+from unittest.mock import patch
+
+from esr_lab.plotter import ESRPlotter
+from esr_lab.spectrum import ESRSpectrum
+
+
+def test_plot_calls_show():
+    spectrum = ESRSpectrum(field=np.array([1, 2]), intensity=np.array([3, 4]))
+    plotter = ESRPlotter()
+
+    with patch("matplotlib.pyplot.show") as show_mock:
+        plotter.plot(spectrum)
+        show_mock.assert_called_once()

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pandas as pd
+
+from esr_lab.spectrum import ESRSpectrum
+
+
+def test_from_dataframe():
+    df = pd.DataFrame({
+        "field": [1.0, 2.0, 3.0],
+        "intensity": [0.1, 0.2, 0.3],
+        "extra": [7, 8, 9],
+    })
+
+    spectrum = ESRSpectrum.from_dataframe(df)
+
+    assert np.array_equal(spectrum.field, df.iloc[:, 0].to_numpy())
+    assert np.array_equal(spectrum.intensity, df.iloc[:, 1].to_numpy())


### PR DESCRIPTION
## Summary
- Add tests for ESRSpectrum.from_dataframe, ensuring correct array conversion
- Cover ESRLoader CSV parsing for comma and semicolon delimiters
- Verify ESRPlotter invokes Matplotlib show
- Test command-line and GUI entry points to ensure they load data and plot without errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac837463d483249d4b53179897e545