### PR TITLE
Add peak finding utility

### DIFF
--- a/esr_lab/__init__.py
+++ b/esr_lab/__init__.py
@@ -3,9 +3,11 @@
 from .spectrum import ESRSpectrum
 from .io import ESRLoader
 from .plotter import ESRPlotter
+from .analysis import find_peak
 
 __all__ = [
     "ESRSpectrum",
     "ESRLoader",
     "ESRPlotter",
+    "find_peak",
 ]

--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -1,0 +1,54 @@
+"""Analysis utilities for ESR data."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import find_peaks
+
+
+def find_peak(field: np.ndarray, intensity: np.ndarray, start: float, end: float) -> int:
+    """Find the most prominent peak within a magnetic field window.
+
+    The function filters the provided ``field`` and ``intensity`` arrays to the
+    region between ``start`` and ``end``. Local maxima and minima are then
+    detected and the index of the peak with the largest absolute intensity is
+    returned. The index refers to the position in the original arrays.
+
+    Parameters
+    ----------
+    field:
+        Array of magnetic-field values.
+    intensity:
+        Array of recorded intensity values corresponding to ``field``.
+    start:
+        Lower bound of the magnetic-field window.
+    end:
+        Upper bound of the magnetic-field window.
+
+    Returns
+    -------
+    int
+        Index of the most prominent peak within the specified range.
+
+    Raises
+    ------
+    ValueError
+        If no data points fall within the specified range.
+    """
+    mask = (field >= start) & (field <= end)
+    if not np.any(mask):
+        raise ValueError("No data points within the specified range.")
+
+    idx_range = np.where(mask)[0]
+    sub_intensity = intensity[idx_range]
+
+    peaks_max, _ = find_peaks(sub_intensity)
+    peaks_min, _ = find_peaks(-sub_intensity)
+    peaks = np.concatenate((peaks_max, peaks_min))
+
+    if peaks.size == 0:
+        rel_index = int(np.argmax(np.abs(sub_intensity)))
+    else:
+        rel_index = int(peaks[np.argmax(np.abs(sub_intensity[peaks]))])
+
+    return int(idx_range[rel_index])

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from esr_lab import find_peak
+
+
+def test_find_peak_single_peak():
+    field = np.linspace(0, 10, 500)
+    intensity = np.exp(-(field - 5) ** 2)
+
+    idx = find_peak(field, intensity, 4, 6)
+
+    assert idx == np.argmax(intensity)
+
+
+def test_find_peak_multiple_peaks():
+    field = np.linspace(0, 10, 500)
+    intensity = (
+        np.exp(-(field - 3) ** 2)  # smaller positive peak
+        - 2 * np.exp(-(field - 7) ** 2)  # larger negative peak
+    )
+
+    idx = find_peak(field, intensity, 0, 10)
+
+    assert idx == np.argmin(intensity)


### PR DESCRIPTION
## Summary
- add `find_peak` helper to locate dominant peak in a field range
- expose new helper via `esr_lab` package
- cover peak detection with unit tests for single and multiple peak scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac8cd0ad308324b5a5ffd7be4ca4f8