### PR TITLE
Add FWHM calculation and unit tests for ESR peaks

### DIFF
--- a/esr_lab/__init__.py
+++ b/esr_lab/__init__.py
@@ -3,11 +3,12 @@
 from .spectrum import ESRSpectrum
 from .io import ESRLoader
 from .plotter import ESRPlotter
-from .analysis import find_peak
+from .analysis import find_peak, calc_fwhm
 
 __all__ = [
     "ESRSpectrum",
     "ESRLoader",
     "ESRPlotter",
     "find_peak",
+    "calc_fwhm",
 ]

--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -52,3 +52,66 @@ def find_peak(field: np.ndarray, intensity: np.ndarray, start: float, end: float
         rel_index = int(peaks[np.argmax(np.abs(sub_intensity[peaks]))])
 
     return int(idx_range[rel_index])
+
+
+def calc_fwhm(field: np.ndarray, intensity: np.ndarray, peak_idx: int) -> float:
+    """Calculate the full width at half maximum (FWHM) of a peak.
+
+    The function determines the half-maximum level relative to the intensity of
+    the peak at ``peak_idx``. Linear interpolation of the neighbouring points is
+    used to locate where the curve crosses this level on both sides of the peak.
+
+    Parameters
+    ----------
+    field:
+        Array of magnetic-field values.
+    intensity:
+        Array of intensity values corresponding to ``field``.
+    peak_idx:
+        Index of the peak for which the FWHM should be calculated.
+
+    Returns
+    -------
+    float
+        The full width at half maximum in the same units as ``field``.
+
+    Raises
+    ------
+    ValueError
+        If the half-maximum level cannot be located on either side of the
+        peak.
+    """
+
+    peak_intensity = intensity[peak_idx]
+    half_max = peak_intensity / 2.0
+
+    # search to the left of the peak for the half-maximum crossing
+    left = None
+    for i in range(peak_idx, 0, -1):
+        y0 = intensity[i - 1] - half_max
+        y1 = intensity[i] - half_max
+        if y0 == 0:
+            left = field[i - 1]
+            break
+        if y0 * y1 < 0:
+            x0, x1 = field[i - 1], field[i]
+            left = x0 + (half_max - intensity[i - 1]) * (x1 - x0) / (intensity[i] - intensity[i - 1])
+            break
+
+    # search to the right of the peak for the half-maximum crossing
+    right = None
+    for i in range(peak_idx, len(field) - 1):
+        y0 = intensity[i] - half_max
+        y1 = intensity[i + 1] - half_max
+        if y1 == 0:
+            right = field[i + 1]
+            break
+        if y0 * y1 < 0:
+            x0, x1 = field[i], field[i + 1]
+            right = x0 + (half_max - intensity[i]) * (x1 - x0) / (intensity[i + 1] - intensity[i])
+            break
+
+    if left is None or right is None:
+        raise ValueError("Half-maximum not found on both sides of the peak.")
+
+    return float(right - left)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from esr_lab import find_peak
+from esr_lab import calc_fwhm, find_peak
 
 
 def test_find_peak_single_peak():
@@ -22,3 +22,33 @@ def test_find_peak_multiple_peaks():
     idx = find_peak(field, intensity, 0, 10)
 
     assert idx == np.argmin(intensity)
+
+
+def test_calc_fwhm_symmetric_peak():
+    field = np.linspace(-5, 5, 10001)
+    sigma = 0.5
+    intensity = np.exp(-(field ** 2) / (2 * sigma**2))
+    peak_idx = np.argmax(intensity)
+
+    width = calc_fwhm(field, intensity, peak_idx)
+    expected = 2 * np.sqrt(2 * np.log(2)) * sigma
+
+    assert np.isclose(width, expected, atol=1e-3)
+
+
+def test_calc_fwhm_asymmetric_peak():
+    field = np.linspace(-5, 5, 10001)
+    mu = 0.0
+    sigma_left = 0.5
+    sigma_right = 1.0
+    intensity = np.where(
+        field < mu,
+        np.exp(-((field - mu) ** 2) / (2 * sigma_left**2)),
+        np.exp(-((field - mu) ** 2) / (2 * sigma_right**2)),
+    )
+    peak_idx = np.argmax(intensity)
+
+    width = calc_fwhm(field, intensity, peak_idx)
+    expected = np.sqrt(2 * np.log(2)) * (sigma_left + sigma_right)
+
+    assert np.isclose(width, expected, atol=1e-3)


### PR DESCRIPTION
## Summary
- add `calc_fwhm` to compute full width at half maximum using interpolation
- expose `calc_fwhm` in package API
- test FWHM computation for symmetric and asymmetric peaks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac8e40d254832485f1074dab50bbc9