### PR TITLE
Add interactive span selector for peak analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project is at an early stage — we’re starting from the basics and will 
 - Display raw spectra.
 - Basic plotting and inspection tools.
 - Simple GUI for selecting a data file to plot.
+- Interactive span selection to measure peak position and FWHM.
 
 ## Requirements
 - Python 3.10+
@@ -29,6 +30,10 @@ Or launch the GUI to choose a file interactively:
 ```bash
 python -m esr_lab.gui
 ```
+
+After the spectrum is shown, drag the mouse twice over two different peaks.
+The application will calculate the peak position and full width at half
+maximum (FWHM) for each selection and display the results.
 
 ## Project Goals
 

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -1,4 +1,10 @@
-"""Simple GUI for selecting ESR data files and visualizing spectra."""
+"""Simple GUI utilities for visualizing and analysing ESR spectra.
+
+This module now provides an interactive plot where users can select two
+magnetic-field ranges using a :class:`matplotlib.widgets.SpanSelector`. For
+each selected window the peak position and full width at half maximum (FWHM)
+are calculated and displayed.
+"""
 
 from __future__ import annotations
 
@@ -6,12 +12,62 @@ from pathlib import Path
 import tkinter as tk
 from tkinter import filedialog, messagebox
 
+import matplotlib.pyplot as plt
+from matplotlib.widgets import SpanSelector
+
+from .analysis import calc_fwhm, find_peak
 from .io import ESRLoader
-from .plotter import ESRPlotter
+
+
+class SpanPeakSelector:
+    """Interactive peak analysis using span selections.
+
+    Parameters
+    ----------
+    spectrum:
+        The spectrum to analyse.
+    """
+
+    def __init__(self, spectrum):
+        self.spectrum = spectrum
+        self.ranges: list[tuple[float, float]] = []
+        self.fig, self.ax = plt.subplots()
+        self.ax.plot(spectrum.field, spectrum.intensity)
+        self.ax.set_xlabel("Magnetic Field")
+        self.ax.set_ylabel("Intensity")
+        self.ax.set_title("ESR Spectrum")
+        self.selector = SpanSelector(self.ax, self.onselect, "horizontal", useblit=True)
+
+    def onselect(self, xmin: float, xmax: float) -> None:
+        """Handle span selections and perform peak analysis.
+
+        The start and end of the selection are stored. After two ranges have
+        been selected, the most prominent peak and its FWHM are calculated for
+        each range and the results shown in a message box.
+        """
+
+        start, end = sorted((xmin, xmax))
+        self.ranges.append((start, end))
+        if len(self.ranges) < 2:
+            return
+
+        self.selector.disconnect_events()
+        lines = []
+        for i, (start, end) in enumerate(self.ranges, start=1):
+            peak_idx = find_peak(self.spectrum.field, self.spectrum.intensity, start, end)
+            fwhm = calc_fwhm(self.spectrum.field, self.spectrum.intensity, peak_idx)
+            field_val = self.spectrum.field[peak_idx]
+            lines.append(f"Peak {i}: field={field_val:.3f}, FWHM={fwhm:.3f}")
+        messagebox.showinfo("Peak analysis", "\n".join(lines))
+
+    def show(self) -> None:
+        """Display the plot."""
+
+        plt.show()
 
 
 def main() -> None:
-    """Launch a file selection dialog and plot the chosen ESR spectrum."""
+    """Launch a file selection dialog and start the interactive analyser."""
     root = tk.Tk()
     root.withdraw()  # Hide the root window
 
@@ -25,8 +81,8 @@ def main() -> None:
 
     try:
         spectrum = ESRLoader.load_csv(Path(file_path))
-        plotter = ESRPlotter()
-        plotter.plot(spectrum)
+        selector = SpanPeakSelector(spectrum)
+        selector.show()
     except Exception as exc:  # pragma: no cover - GUI error handling
         messagebox.showerror("Error", str(exc))
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,6 +1,10 @@
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
 from unittest.mock import patch
 
 from esr_lab import gui
+from esr_lab.spectrum import ESRSpectrum
 
 
 def test_gui_main(monkeypatch, tmp_path):
@@ -14,6 +18,24 @@ def test_gui_main(monkeypatch, tmp_path):
     monkeypatch.setattr(gui.tk, "Tk", lambda: DummyTk())
     monkeypatch.setattr(gui.filedialog, "askopenfilename", lambda **kwargs: str(csv_file))
 
-    with patch("esr_lab.gui.ESRPlotter.plot") as plot_mock:
+    with patch("esr_lab.gui.SpanPeakSelector") as selector_mock:
         gui.main()
-        plot_mock.assert_called_once()
+        selector_mock.assert_called_once()
+        selector_mock.return_value.show.assert_called_once()
+
+
+def test_span_selector_analysis():
+    spectrum = ESRSpectrum(field=np.arange(10.0), intensity=np.zeros(10))
+    selector = gui.SpanPeakSelector(spectrum)
+
+    with patch("esr_lab.gui.find_peak", return_value=3) as fp, \
+        patch("esr_lab.gui.calc_fwhm", return_value=0.5) as cf, \
+        patch("esr_lab.gui.messagebox.showinfo") as info:
+        selector.onselect(1.0, 2.0)
+        selector.onselect(5.0, 8.0)
+
+        assert selector.ranges == [(1.0, 2.0), (5.0, 8.0)]
+        assert fp.call_count == 2
+        assert cf.call_count == 2
+        info.assert_called_once()
+


### PR DESCRIPTION
## Summary
- Add `SpanPeakSelector` to `gui` to interactively select two ranges and compute peak positions and FWHM
- Document new span selection workflow in README
- Test GUI span selection using mocked events

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac914a6d1c8324ad2b4e373b661d79