### PR TITLE
Add peak highlighting and FWHM shading to ESRPlotter

### DIFF
--- a/esr_lab/plotter.py
+++ b/esr_lab/plotter.py
@@ -1,6 +1,7 @@
 """Plotting utilities for ESR spectra."""
 
 import matplotlib.pyplot as plt
+from typing import Optional, Sequence
 
 from .spectrum import ESRSpectrum
 
@@ -8,13 +9,24 @@ from .spectrum import ESRSpectrum
 class ESRPlotter:
     """Plotter for ESR spectra."""
 
-    def plot(self, spectrum: ESRSpectrum) -> None:
+    def plot(
+        self,
+        spectrum: ESRSpectrum,
+        peaks: Optional[Sequence[float]] = None,
+        widths: Optional[Sequence[float]] = None,
+    ) -> None:
         """Plot the provided spectrum.
 
         Parameters
         ----------
         spectrum:
             The spectrum to plot.
+        peaks:
+            Optional iterable of peak positions to highlight.
+        widths:
+            Optional iterable of full width at half maximum values corresponding
+            to ``peaks``. When provided, shaded regions are drawn to visualise
+            the width at half maximum for each peak.
         """
 
         fig, ax = plt.subplots()
@@ -22,4 +34,17 @@ class ESRPlotter:
         ax.set_xlabel("Magnetic Field")
         ax.set_ylabel("Intensity")
         ax.set_title("ESR Spectrum")
+
+        if peaks is not None:
+            # If widths are provided, iterate over both.  Otherwise simply draw
+            # a vertical line to mark the peak position.
+            widths_iter = widths if widths is not None else []
+            for i, peak in enumerate(peaks):
+                ax.axvline(peak, color="red", linestyle="--")
+                if i < len(widths_iter):
+                    half_width = widths_iter[i] / 2.0
+                    left = peak - half_width
+                    right = peak + half_width
+                    ax.axvspan(left, right, color="orange", alpha=0.3)
+
         plt.show()

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1,6 +1,7 @@
 import numpy as np
 import matplotlib
 matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 from unittest.mock import patch
 
 from esr_lab.plotter import ESRPlotter
@@ -14,3 +15,24 @@ def test_plot_calls_show():
     with patch("matplotlib.pyplot.show") as show_mock:
         plotter.plot(spectrum)
         show_mock.assert_called_once()
+    plt.close("all")
+
+
+def test_plot_peaks_and_widths():
+    spectrum = ESRSpectrum(field=np.linspace(0, 10, 50), intensity=np.zeros(50))
+    plotter = ESRPlotter()
+    peaks = [5.0]
+    widths = [2.0]
+
+    with patch("matplotlib.pyplot.show"):
+        plotter.plot(spectrum, peaks=peaks, widths=widths)
+
+    fig = plt.gcf()
+    ax = fig.axes[0]
+
+    # A shaded region should be created for the FWHM
+    assert len(ax.patches) == 1
+    fwhm_patch = ax.patches[0]
+    assert fwhm_patch.get_x() == peaks[0] - widths[0] / 2
+    assert fwhm_patch.get_width() == widths[0]
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- Extend `ESRPlotter.plot` with optional `peaks` and `widths` arguments
- Shade regions and draw markers for peak FWHM when provided
- Close plots in tests and add coverage for peak/FWHM rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac914b26f083249ae5319df39b1d3b