### PR TITLE
Handle paired derivative peaks for ESR FWHM

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ Or launch the GUI to choose a file interactively:
 python -m esr_lab.gui
 ```
 
-After the spectrum is shown, drag the mouse twice over two different peaks.
-The application will calculate the peak position and full width at half
-maximum (FWHM) for each selection and display the results.
+After the spectrum is shown, drag the mouse over a region that contains the
+positive and negative peaks of an absorption line. The program determines both
+extrema and reports their positions and the full width at half maximum (FWHM)
+given by the distance between them. Repeat the selection for additional
+absorptions.
 
 ## Project Goals
 

--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -6,13 +6,15 @@ import numpy as np
 from scipy.signal import find_peaks
 
 
-def find_peak(field: np.ndarray, intensity: np.ndarray, start: float, end: float) -> int:
-    """Find the most prominent peak within a magnetic field window.
+def find_peak(
+    field: np.ndarray, intensity: np.ndarray, start: float, end: float
+) -> tuple[int, int]:
+    """Locate the positive and negative peaks within a field window.
 
-    The function filters the provided ``field`` and ``intensity`` arrays to the
-    region between ``start`` and ``end``. Local maxima and minima are then
-    detected and the index of the peak with the largest absolute intensity is
-    returned. The index refers to the position in the original arrays.
+    ESR spectra recorded in derivative mode exhibit a positive and a negative
+    extremum for each absorption line.  When the user selects a magnetic-field
+    region, both extrema have to be determined so that the distance between
+    them can be used as an estimate for the full width at half maximum (FWHM).
 
     Parameters
     ----------
@@ -27,14 +29,17 @@ def find_peak(field: np.ndarray, intensity: np.ndarray, start: float, end: float
 
     Returns
     -------
-    int
-        Index of the most prominent peak within the specified range.
+    tuple[int, int]
+        Indices of the most prominent positive and negative peaks within the
+        specified range. The order of the tuple is ``(positive_idx, negative_idx)``.
 
     Raises
     ------
     ValueError
-        If no data points fall within the specified range.
+        If no data points fall within the specified range or if either a
+        positive or negative peak cannot be located.
     """
+
     mask = (field >= start) & (field <= end)
     if not np.any(mask):
         raise ValueError("No data points within the specified range.")
@@ -42,76 +47,43 @@ def find_peak(field: np.ndarray, intensity: np.ndarray, start: float, end: float
     idx_range = np.where(mask)[0]
     sub_intensity = intensity[idx_range]
 
-    peaks_max, _ = find_peaks(sub_intensity)
-    peaks_min, _ = find_peaks(-sub_intensity)
-    peaks = np.concatenate((peaks_max, peaks_min))
+    pos_peaks, _ = find_peaks(sub_intensity)
+    neg_peaks, _ = find_peaks(-sub_intensity)
 
-    if peaks.size == 0:
-        rel_index = int(np.argmax(np.abs(sub_intensity)))
-    else:
-        rel_index = int(peaks[np.argmax(np.abs(sub_intensity[peaks]))])
+    if pos_peaks.size == 0 or neg_peaks.size == 0:
+        raise ValueError("Both positive and negative peaks are required in the range.")
 
-    return int(idx_range[rel_index])
+    pos_rel = int(pos_peaks[np.argmax(sub_intensity[pos_peaks])])
+    neg_rel = int(neg_peaks[np.argmin(sub_intensity[neg_peaks])])
+
+    return int(idx_range[pos_rel]), int(idx_range[neg_rel])
 
 
-def calc_fwhm(field: np.ndarray, intensity: np.ndarray, peak_idx: int) -> float:
-    """Calculate the full width at half maximum (FWHM) of a peak.
+def calc_fwhm(
+    field: np.ndarray, intensity: np.ndarray, pos_idx: int, neg_idx: int
+) -> float:
+    """Estimate the full width at half maximum from a peak pair.
 
-    The function determines the half-maximum level relative to the intensity of
-    the peak at ``peak_idx``. Linear interpolation of the neighbouring points is
-    used to locate where the curve crosses this level on both sides of the peak.
+    In derivative-mode ESR the distance between the positive and negative
+    extrema of an absorption line is proportional to its FWHM.  Once both peak
+    indices are known, the width can therefore be approximated simply as the
+    absolute difference of their field values.
 
     Parameters
     ----------
     field:
         Array of magnetic-field values.
     intensity:
-        Array of intensity values corresponding to ``field``.
-    peak_idx:
-        Index of the peak for which the FWHM should be calculated.
+        Unused array of intensity values kept for API compatibility.
+    pos_idx:
+        Index of the positive peak.
+    neg_idx:
+        Index of the negative peak.
 
     Returns
     -------
     float
-        The full width at half maximum in the same units as ``field``.
-
-    Raises
-    ------
-    ValueError
-        If the half-maximum level cannot be located on either side of the
-        peak.
+        The absolute distance between the positive and negative peak positions.
     """
 
-    peak_intensity = intensity[peak_idx]
-    half_max = peak_intensity / 2.0
-
-    # search to the left of the peak for the half-maximum crossing
-    left = None
-    for i in range(peak_idx, 0, -1):
-        y0 = intensity[i - 1] - half_max
-        y1 = intensity[i] - half_max
-        if y0 == 0:
-            left = field[i - 1]
-            break
-        if y0 * y1 < 0:
-            x0, x1 = field[i - 1], field[i]
-            left = x0 + (half_max - intensity[i - 1]) * (x1 - x0) / (intensity[i] - intensity[i - 1])
-            break
-
-    # search to the right of the peak for the half-maximum crossing
-    right = None
-    for i in range(peak_idx, len(field) - 1):
-        y0 = intensity[i] - half_max
-        y1 = intensity[i + 1] - half_max
-        if y1 == 0:
-            right = field[i + 1]
-            break
-        if y0 * y1 < 0:
-            x0, x1 = field[i], field[i + 1]
-            right = x0 + (half_max - intensity[i]) * (x1 - x0) / (intensity[i + 1] - intensity[i])
-            break
-
-    if left is None or right is None:
-        raise ValueError("Half-maximum not found on both sides of the peak.")
-
-    return float(right - left)
+    return float(abs(field[pos_idx] - field[neg_idx]))

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -54,10 +54,17 @@ class SpanPeakSelector:
         self.selector.disconnect_events()
         lines = []
         for i, (start, end) in enumerate(self.ranges, start=1):
-            peak_idx = find_peak(self.spectrum.field, self.spectrum.intensity, start, end)
-            fwhm = calc_fwhm(self.spectrum.field, self.spectrum.intensity, peak_idx)
-            field_val = self.spectrum.field[peak_idx]
-            lines.append(f"Peak {i}: field={field_val:.3f}, FWHM={fwhm:.3f}")
+            pos_idx, neg_idx = find_peak(
+                self.spectrum.field, self.spectrum.intensity, start, end
+            )
+            fwhm = calc_fwhm(
+                self.spectrum.field, self.spectrum.intensity, pos_idx, neg_idx
+            )
+            pos_field = self.spectrum.field[pos_idx]
+            neg_field = self.spectrum.field[neg_idx]
+            lines.append(
+                f"Absorption {i}: pos={pos_field:.3f}, neg={neg_field:.3f}, FWHM={fwhm:.3f}"
+            )
         messagebox.showinfo("Peak analysis", "\n".join(lines))
 
     def show(self) -> None:

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,54 +1,24 @@
 import numpy as np
+import pytest
 
-from esr_lab import calc_fwhm, find_peak
-
-
-def test_find_peak_single_peak():
-    field = np.linspace(0, 10, 500)
-    intensity = np.exp(-(field - 5) ** 2)
-
-    idx = find_peak(field, intensity, 4, 6)
-
-    assert idx == np.argmax(intensity)
+from esr_lab import find_peak, calc_fwhm
 
 
-def test_find_peak_multiple_peaks():
-    field = np.linspace(0, 10, 500)
-    intensity = (
-        np.exp(-(field - 3) ** 2)  # smaller positive peak
-        - 2 * np.exp(-(field - 7) ** 2)  # larger negative peak
-    )
+def test_find_peak_pair():
+    field = np.arange(10.0)
+    intensity = np.array([0, 1, 0, -1, 0, 2, 0, -2, 0, 0])
 
-    idx = find_peak(field, intensity, 0, 10)
+    pos_idx, neg_idx = find_peak(field, intensity, 4, 8)
 
-    assert idx == np.argmin(intensity)
+    assert pos_idx == 5
+    assert neg_idx == 7
 
 
-def test_calc_fwhm_symmetric_peak():
+def test_calc_fwhm_from_peaks():
     field = np.linspace(-5, 5, 10001)
-    sigma = 0.5
-    intensity = np.exp(-(field ** 2) / (2 * sigma**2))
-    peak_idx = np.argmax(intensity)
+    intensity = field * np.exp(-field**2 / 2)
 
-    width = calc_fwhm(field, intensity, peak_idx)
-    expected = 2 * np.sqrt(2 * np.log(2)) * sigma
+    pos_idx, neg_idx = find_peak(field, intensity, -2, 2)
+    width = calc_fwhm(field, intensity, pos_idx, neg_idx)
 
-    assert np.isclose(width, expected, atol=1e-3)
-
-
-def test_calc_fwhm_asymmetric_peak():
-    field = np.linspace(-5, 5, 10001)
-    mu = 0.0
-    sigma_left = 0.5
-    sigma_right = 1.0
-    intensity = np.where(
-        field < mu,
-        np.exp(-((field - mu) ** 2) / (2 * sigma_left**2)),
-        np.exp(-((field - mu) ** 2) / (2 * sigma_right**2)),
-    )
-    peak_idx = np.argmax(intensity)
-
-    width = calc_fwhm(field, intensity, peak_idx)
-    expected = np.sqrt(2 * np.log(2)) * (sigma_left + sigma_right)
-
-    assert np.isclose(width, expected, atol=1e-3)
+    assert np.isclose(width, 2.0, atol=1e-3)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -28,7 +28,7 @@ def test_span_selector_analysis():
     spectrum = ESRSpectrum(field=np.arange(10.0), intensity=np.zeros(10))
     selector = gui.SpanPeakSelector(spectrum)
 
-    with patch("esr_lab.gui.find_peak", return_value=3) as fp, \
+    with patch("esr_lab.gui.find_peak", return_value=(1, 3)) as fp, \
         patch("esr_lab.gui.calc_fwhm", return_value=0.5) as cf, \
         patch("esr_lab.gui.messagebox.showinfo") as info:
         selector.onselect(1.0, 2.0)


### PR DESCRIPTION
## Summary
- Detect positive/negative peak pairs within a selected field range
- Derive FWHM from the distance between peak pairs in the GUI and analysis utilities
- Clarify README instructions for selecting paired peaks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac9524092083249a910ca96b7ad12f