### PR TITLE
Restore graph toolbar

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.widgets import SpanSelector
 import matplotlib.pyplot as plt
 
@@ -129,7 +129,10 @@ class SpanPeakSelector:
         self.ax.set_ylabel("Intensity")
         canvas = FigureCanvasTkAgg(fig, master=plot_frame)
         canvas.draw()
+        toolbar = NavigationToolbar2Tk(canvas, plot_frame, pack_toolbar=False)
+        toolbar.update()
         canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+        toolbar.pack(side=tk.BOTTOM, fill=tk.X)
 
         self.analyse_btn = tk.Button(panel, text="Analyse FWHM", command=self.start_analysis)
         self.analyse_btn.pack(padx=5, pady=5)


### PR DESCRIPTION
## Summary
- Reintroduce Matplotlib navigation toolbar to GUI so users can modify graphs while using the analysis panel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc780fd3c8324ba4722261b433662