### PR TITLE
Add configurable subplot styling helper

### DIFF
--- a/esr_lab/plotter.py
+++ b/esr_lab/plotter.py
@@ -1,7 +1,7 @@
 """Plotting utilities for ESR spectra."""
 
 import matplotlib.pyplot as plt
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 
 from .spectrum import ESRSpectrum
 
@@ -48,3 +48,76 @@ class ESRPlotter:
                     ax.axvspan(left, right, color="orange", alpha=0.3)
 
         plt.show()
+
+
+def configure_subplot(
+    ax: plt.Axes,
+    *,
+    color: Optional[str] = None,
+    linewidth: Optional[float] = None,
+    marker: Optional[str] = None,
+    x_label: Optional[str] = None,
+    y_label: Optional[str] = None,
+    title: Optional[str] = None,
+    font_size: Optional[float] = None,
+    x_range: Optional[Tuple[float, float]] = None,
+    y_range: Optional[Tuple[float, float]] = None,
+    x_ticks: Optional[Sequence[float]] = None,
+    y_ticks: Optional[Sequence[float]] = None,
+) -> None:
+    """Configure common display properties of a Matplotlib subplot.
+
+    The function offers a thin convenience wrapper around Matplotlib's ``Axes``
+    methods so that unit tests – and eventually users – can easily tweak the
+    appearance of a plot without touching the Matplotlib API directly.
+    Parameters are optional; only the supplied ones are applied.
+
+    Parameters
+    ----------
+    ax:
+        The :class:`~matplotlib.axes.Axes` instance to configure.
+    color, linewidth, marker:
+        Styling options applied to all lines currently present in ``ax``.
+    x_label, y_label, title:
+        Axis and figure titles.
+    font_size:
+        Font size for axis labels, tick labels and the title.
+    x_range, y_range:
+        Two-tuples specifying the visible axis range.
+    x_ticks, y_ticks:
+        Explicit tick locations for the respective axes.
+    """
+
+    # Line styling -------------------------------------------------------
+    if color is not None or linewidth is not None or marker is not None:
+        for line in ax.lines:
+            if color is not None:
+                line.set_color(color)
+            if linewidth is not None:
+                line.set_linewidth(linewidth)
+            if marker is not None:
+                line.set_marker(marker)
+
+    # Axis labels and title ---------------------------------------------
+    if x_label is not None:
+        ax.set_xlabel(x_label, fontsize=font_size)
+    if y_label is not None:
+        ax.set_ylabel(y_label, fontsize=font_size)
+    if title is not None:
+        ax.set_title(title, fontsize=font_size)
+
+    if font_size is not None:
+        for label in ax.get_xticklabels() + ax.get_yticklabels():
+            label.set_fontsize(font_size)
+
+    # Axis ranges --------------------------------------------------------
+    if x_range is not None:
+        ax.set_xlim(x_range)
+    if y_range is not None:
+        ax.set_ylim(y_range)
+
+    # Tick marks ---------------------------------------------------------
+    if x_ticks is not None:
+        ax.set_xticks(list(x_ticks))
+    if y_ticks is not None:
+        ax.set_yticks(list(y_ticks))

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -4,7 +4,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from unittest.mock import patch
 
-from esr_lab.plotter import ESRPlotter
+from esr_lab.plotter import ESRPlotter, configure_subplot
 from esr_lab.spectrum import ESRSpectrum
 
 
@@ -35,4 +35,46 @@ def test_plot_peaks_and_widths():
     fwhm_patch = ax.patches[0]
     assert fwhm_patch.get_x() == peaks[0] - widths[0] / 2
     assert fwhm_patch.get_width() == widths[0]
+    plt.close(fig)
+
+
+def test_configure_subplot_allows_customisation():
+    spectrum = ESRSpectrum(field=np.array([0, 1, 2]), intensity=np.array([1, 2, 3]))
+    plotter = ESRPlotter()
+
+    with patch("matplotlib.pyplot.show"):
+        plotter.plot(spectrum)
+
+    fig = plt.gcf()
+    ax = fig.axes[0]
+
+    configure_subplot(
+        ax,
+        color="green",
+        linewidth=2,
+        marker="o",
+        x_label="X axis",
+        y_label="Y axis",
+        title="Title",
+        font_size=14,
+        x_range=(0, 2),
+        y_range=(1, 3),
+        x_ticks=[0, 1, 2],
+        y_ticks=[1, 2, 3],
+    )
+
+    line = ax.lines[0]
+    assert line.get_color() == "green"
+    assert line.get_linewidth() == 2
+    assert line.get_marker() == "o"
+    assert ax.get_xlabel() == "X axis"
+    assert ax.get_ylabel() == "Y axis"
+    assert ax.get_title() == "Title"
+    assert tuple(ax.get_xlim()) == (0, 2)
+    assert tuple(ax.get_ylim()) == (1, 3)
+    assert list(ax.get_xticks()) == [0, 1, 2]
+    assert list(ax.get_yticks()) == [1, 2, 3]
+    assert ax.xaxis.label.get_fontsize() == 14
+    assert ax.yaxis.label.get_fontsize() == 14
+    assert ax.title.get_fontsize() == 14
     plt.close(fig)


### PR DESCRIPTION
## Summary
- Add `configure_subplot` helper to adjust line style, axis labels, ranges, ticks and fonts
- Test `configure_subplot` to ensure subplot customisation options work

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc92590948324a7f0b73b8072f086