### PR TITLE
Add Lorentzian derivative fitting for ESR spectra

### DIFF
--- a/esr_lab/__init__.py
+++ b/esr_lab/__init__.py
@@ -3,7 +3,7 @@
 from .spectrum import ESRSpectrum
 from .io import ESRLoader
 from .plotter import ESRPlotter
-from .analysis import find_peak, calc_fwhm
+from .analysis import find_peak, calc_fwhm, fit_lorentzian_derivative
 
 __all__ = [
     "ESRSpectrum",
@@ -11,4 +11,5 @@ __all__ = [
     "ESRPlotter",
     "find_peak",
     "calc_fwhm",
+    "fit_lorentzian_derivative",
 ]

--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -87,3 +87,64 @@ def calc_fwhm(
     """
 
     return float(abs(field[pos_idx] - field[neg_idx]))
+
+
+def fit_lorentzian_derivative(
+    field: np.ndarray,
+    intensity: np.ndarray,
+    p0: tuple[float, float, float, float] | None = None,
+) -> tuple[float, float, float, float]:
+    """Fit a derivative ESR line to a Lorentzian derivative model.
+
+    The measured ESR signal in derivative mode can be represented as the
+    derivative of a superposition of an absorptive (symmetric) and a dispersive
+    (antisymmetric) Lorentzian line.  This function fits the recorded data to
+    this model using non-linear least squares and returns the characteristic
+    parameters of the resonance.
+
+    The model function is::
+
+        dI/dH = A * d/dH L_abs(H) + B * d/dH L_disp(H)
+
+    where ``L_abs`` is the Lorentzian absorption line and ``L_disp`` is the
+    dispersive counterpart.  ``A`` and ``B`` denote the amplitudes of the
+    symmetric and antisymmetric contributions respectively.
+
+    Parameters
+    ----------
+    field:
+        Array of magnetic-field values.
+    intensity:
+        Array of derivative signal intensities corresponding to ``field``.
+    p0:
+        Optional initial guess for the parameters
+        ``(H_res, delta, A, B)``. ``delta`` is the half width at half maximum
+        (HWHM).  If omitted, a heuristic guess is derived from the data.
+
+    Returns
+    -------
+    tuple[float, float, float, float]
+        Fitted parameters ``(H_res, delta, A, B)``.
+    """
+
+    def _model(H: np.ndarray, H_res: float, delta: float, A: float, B: float) -> np.ndarray:
+        x = H - H_res
+        denom = (x**2 + delta**2) ** 2
+        sym = -2.0 * delta**2 * x / denom
+        disp = delta * (delta**2 - x**2) / denom
+        return A * sym + B * disp
+
+    if p0 is None:
+        pos_idx = int(np.argmax(intensity))
+        neg_idx = int(np.argmin(intensity))
+        h_res_guess = (field[pos_idx] + field[neg_idx]) / 2.0
+        delta_guess = abs(field[pos_idx] - field[neg_idx]) / 2.0
+        a_guess = (intensity[pos_idx] - intensity[neg_idx]) / 2.0
+        b_guess = 0.0
+        p0 = (h_res_guess, delta_guess, a_guess, b_guess)
+
+    from scipy.optimize import curve_fit
+
+    popt, _ = curve_fit(_model, field, intensity, p0=p0)
+    h_res, delta, A, B = popt
+    return float(h_res), float(delta), float(A), float(B)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from esr_lab import find_peak, calc_fwhm
+from esr_lab import find_peak, calc_fwhm, fit_lorentzian_derivative
 
 
 def test_find_peak_pair():
@@ -22,3 +22,18 @@ def test_calc_fwhm_from_peaks():
     width = calc_fwhm(field, intensity, pos_idx, neg_idx)
 
     assert np.isclose(width, 2.0, atol=1e-3)
+
+
+def test_fit_lorentzian_derivative_parameters():
+    field = np.linspace(-10, 10, 1001)
+    H_res, delta, A, B = 1.0, 2.0, 3.0, 1.5
+
+    x = field - H_res
+    denom = (x**2 + delta**2) ** 2
+    intensity = A * (-2.0 * delta**2 * x / denom) + B * (
+        delta * (delta**2 - x**2) / denom
+    )
+
+    params = fit_lorentzian_derivative(field, intensity)
+
+    assert np.allclose(params, (H_res, delta, A, B), atol=1e-6)


### PR DESCRIPTION
## Summary
- add `fit_lorentzian_derivative` to analyze derivative ESR spectra using absorptive and dispersive Lorentzian components
- expose the new fitting function via the package API
- cover the fitting routine with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68accbe93bcc83249459ffa6c02168e3