### PR TITLE
Add Lorentzian fitting button with overlay confirmation

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -13,11 +13,12 @@ from pathlib import Path
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
+import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.widgets import SpanSelector
-import matplotlib.pyplot as plt
 
-from .analysis import calc_fwhm, find_peak
+from .analysis import calc_fwhm, find_peak, fit_lorentzian_derivative
 from .io import ESRLoader
 
 
@@ -44,6 +45,7 @@ class SpanPeakSelector:
         self.ax = None
         self.tree: ttk.Treeview | None = None
         self.analyse_btn: tk.Button | None = None
+        self.fit_btn: tk.Button | None = None
         self.selector: SpanSelector | None = None
 
     # ------------------------------------------------------------------
@@ -112,6 +114,41 @@ class SpanPeakSelector:
         messagebox.showinfo("Peak analysis", "\n".join(lines))
 
     # ------------------------------------------------------------------
+    def fit_lorentzian(self) -> None:
+        """Fit a Lorentzian derivative line and optionally keep the overlay."""
+
+        assert self.ax is not None
+        params = fit_lorentzian_derivative(
+            self.spectrum.field, self.spectrum.intensity
+        )
+
+        h_res, delta, A, B = params
+
+        def _model(H: np.ndarray, H_res: float, delta: float, A: float, B: float):
+            x = H - H_res
+            denom = (x**2 + delta**2) ** 2
+            sym = -2.0 * delta**2 * x / denom
+            disp = delta * (delta**2 - x**2) / denom
+            return A * sym + B * disp
+
+        fit = _model(self.spectrum.field, h_res, delta, A, B)
+        (line,) = self.ax.plot(self.spectrum.field, fit, label="Lorentzian fit")
+        self.ax.legend()
+        self.ax.figure.canvas.draw_idle()
+
+        accept = messagebox.askyesno(
+            "Lorentzian Fit",
+            (
+                f"H_res={h_res:.3f}\n"
+                f"Delta={delta:.3f}\nA={A:.3f}\nB={B:.3f}\nAccept fit?"
+            ),
+        )
+
+        if not accept:
+            line.remove()
+            self.ax.figure.canvas.draw_idle()
+
+    # ------------------------------------------------------------------
     def show(self) -> None:
         """Start the Tkinter main loop and display the analysis GUI."""
 
@@ -134,8 +171,13 @@ class SpanPeakSelector:
         canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
         toolbar.pack(side=tk.BOTTOM, fill=tk.X)
 
-        self.analyse_btn = tk.Button(panel, text="Analyse FWHM", command=self.start_analysis)
+        self.analyse_btn = tk.Button(
+            panel, text="Analyse FWHM", command=self.start_analysis
+        )
         self.analyse_btn.pack(padx=5, pady=5)
+
+        self.fit_btn = tk.Button(panel, text="Fit Lorentzian", command=self.fit_lorentzian)
+        self.fit_btn.pack(padx=5, pady=5)
 
         columns = ("pos_x", "pos_y", "neg_x", "neg_y", "fwhm")
         self.tree = ttk.Treeview(panel, columns=columns, show="headings", height=5)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,6 +1,7 @@
 import numpy as np
 import matplotlib
 matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 from unittest.mock import patch
 
 from esr_lab import gui
@@ -38,4 +39,31 @@ def test_span_selector_analysis():
         assert fp.call_count == 2
         assert cf.call_count == 2
         info.assert_called_once()
+
+
+def test_lorentzian_fit_overlay():
+    spectrum = ESRSpectrum(field=np.linspace(-1, 1, 5), intensity=np.zeros(5))
+    selector = gui.SpanPeakSelector(spectrum)
+
+    fig, selector.ax = plt.subplots()
+    selector.ax.plot(spectrum.field, spectrum.intensity)
+    with patch(
+        "esr_lab.gui.fit_lorentzian_derivative", return_value=(0.0, 1.0, 1.0, 0.0)
+    ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=True) as ask:
+        selector.fit_lorentzian()
+        fit.assert_called_once()
+        ask.assert_called_once()
+        assert len(selector.ax.lines) == 2
+    plt.close(fig)
+
+    fig, selector.ax = plt.subplots()
+    selector.ax.plot(spectrum.field, spectrum.intensity)
+    with patch(
+        "esr_lab.gui.fit_lorentzian_derivative", return_value=(0.0, 1.0, 1.0, 0.0)
+    ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=False) as ask:
+        selector.fit_lorentzian()
+        fit.assert_called_once()
+        ask.assert_called_once()
+        assert len(selector.ax.lines) == 1
+    plt.close(fig)
 


### PR DESCRIPTION
## Summary
- Add a "Fit Lorentzian" button to the analysis GUI that fits a Lorentzian derivative, overlays the curve, and asks the user to accept the fit
- Extend GUI tests to cover Lorentzian fitting overlay behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc4064b0083248290455219bcaf3f