### PR TITLE
Add buttons to fit Lorentzian peaks separately

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -45,7 +45,8 @@ class SpanPeakSelector:
         self.ax = None
         self.tree: ttk.Treeview | None = None
         self.analyse_btn: tk.Button | None = None
-        self.fit_btn: tk.Button | None = None
+        self.fit_btn1: tk.Button | None = None
+        self.fit_btn2: tk.Button | None = None
         self.selector: SpanSelector | None = None
 
     # ------------------------------------------------------------------
@@ -114,13 +115,20 @@ class SpanPeakSelector:
         messagebox.showinfo("Peak analysis", "\n".join(lines))
 
     # ------------------------------------------------------------------
-    def fit_lorentzian(self) -> None:
-        """Fit a Lorentzian derivative line and optionally keep the overlay."""
+    def _fit_lorentzian(self, peak_idx: int) -> None:
+        """Fit a Lorentzian line to the selected peak and optionally keep it."""
 
         assert self.ax is not None
-        params = fit_lorentzian_derivative(
-            self.spectrum.field, self.spectrum.intensity
-        )
+
+        if len(self.ranges) > peak_idx:
+            start, end = self.ranges[peak_idx]
+            mask = (self.spectrum.field >= start) & (self.spectrum.field <= end)
+        else:
+            mask = slice(None)
+
+        field = self.spectrum.field[mask]
+        intensity = self.spectrum.intensity[mask]
+        params = fit_lorentzian_derivative(field, intensity)
 
         h_res, delta, A, B = params
 
@@ -131,8 +139,8 @@ class SpanPeakSelector:
             disp = delta * (delta**2 - x**2) / denom
             return A * sym + B * disp
 
-        fit = _model(self.spectrum.field, h_res, delta, A, B)
-        (line,) = self.ax.plot(self.spectrum.field, fit, label="Lorentzian fit")
+        fit = _model(field, h_res, delta, A, B)
+        (line,) = self.ax.plot(field, fit, label=f"Lorentzian fit peak {peak_idx + 1}")
         self.ax.legend()
         self.ax.figure.canvas.draw_idle()
 
@@ -147,6 +155,16 @@ class SpanPeakSelector:
         if not accept:
             line.remove()
             self.ax.figure.canvas.draw_idle()
+
+    def fit_lorentzian_peak1(self) -> None:
+        """Fit the Lorentzian model to the first peak."""
+
+        self._fit_lorentzian(0)
+
+    def fit_lorentzian_peak2(self) -> None:
+        """Fit the Lorentzian model to the second peak."""
+
+        self._fit_lorentzian(1)
 
     # ------------------------------------------------------------------
     def show(self) -> None:
@@ -176,8 +194,15 @@ class SpanPeakSelector:
         )
         self.analyse_btn.pack(padx=5, pady=5)
 
-        self.fit_btn = tk.Button(panel, text="Fit Lorentzian", command=self.fit_lorentzian)
-        self.fit_btn.pack(padx=5, pady=5)
+        self.fit_btn1 = tk.Button(
+            panel, text="Fit Lorentzian Peak 1", command=self.fit_lorentzian_peak1
+        )
+        self.fit_btn1.pack(padx=5, pady=5)
+
+        self.fit_btn2 = tk.Button(
+            panel, text="Fit Lorentzian Peak 2", command=self.fit_lorentzian_peak2
+        )
+        self.fit_btn2.pack(padx=5, pady=5)
 
         columns = ("pos_x", "pos_y", "neg_x", "neg_y", "fwhm")
         self.tree = ttk.Treeview(panel, columns=columns, show="headings", height=5)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -44,13 +44,14 @@ def test_span_selector_analysis():
 def test_lorentzian_fit_overlay():
     spectrum = ESRSpectrum(field=np.linspace(-1, 1, 5), intensity=np.zeros(5))
     selector = gui.SpanPeakSelector(spectrum)
+    selector.ranges = [(-1, 0), (0, 1)]
 
     fig, selector.ax = plt.subplots()
     selector.ax.plot(spectrum.field, spectrum.intensity)
     with patch(
         "esr_lab.gui.fit_lorentzian_derivative", return_value=(0.0, 1.0, 1.0, 0.0)
     ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=True) as ask:
-        selector.fit_lorentzian()
+        selector.fit_lorentzian_peak1()
         fit.assert_called_once()
         ask.assert_called_once()
         assert len(selector.ax.lines) == 2
@@ -61,7 +62,7 @@ def test_lorentzian_fit_overlay():
     with patch(
         "esr_lab.gui.fit_lorentzian_derivative", return_value=(0.0, 1.0, 1.0, 0.0)
     ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=False) as ask:
-        selector.fit_lorentzian()
+        selector.fit_lorentzian_peak2()
         fit.assert_called_once()
         ask.assert_called_once()
         assert len(selector.ax.lines) == 1


### PR DESCRIPTION
## Summary
- enable fitting of each peak individually with dedicated `fit_lorentzian_peak1/2` methods
- add two GUI buttons to run separate Lorentzian fits for peak 1 and peak 2
- update tests to exercise new peak-specific fit functions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ade78368e08324b7cb16e8fabadafd