### PR TITLE
Add peak-to-peak linewidth analysis

### DIFF
--- a/esr_lab/__init__.py
+++ b/esr_lab/__init__.py
@@ -3,7 +3,12 @@
 from .spectrum import ESRSpectrum
 from .io import ESRLoader
 from .plotter import ESRPlotter
-from .analysis import find_peak, calc_fwhm, fit_lorentzian_derivative
+from .analysis import (
+    find_peak,
+    calc_fwhm,
+    fit_lorentzian_derivative,
+    calc_peak_to_peak,
+)
 
 __all__ = [
     "ESRSpectrum",
@@ -12,4 +17,5 @@ __all__ = [
     "find_peak",
     "calc_fwhm",
     "fit_lorentzian_derivative",
+    "calc_peak_to_peak",
 ]

--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -89,6 +89,36 @@ def calc_fwhm(
     return float(abs(field[pos_idx] - field[neg_idx]))
 
 
+def calc_peak_to_peak(
+    field: np.ndarray, intensity: np.ndarray, pos_idx: int, neg_idx: int
+) -> float:
+    r"""Compute the peak-to-peak separation :math:`\Delta H_{pp}`.
+
+    The peak-to-peak width of a derivative ESR line is defined as the distance
+    in magnetic-field units between the positive and the negative extrema.  It
+    is commonly denoted :math:`\Delta H_{pp}` and is a convenient measure for
+    the line width without converting to the absorption representation.
+
+    Parameters
+    ----------
+    field:
+        Array of magnetic-field values.
+    intensity:
+        Unused array of intensity values kept for API compatibility.
+    pos_idx:
+        Index of the positive peak.
+    neg_idx:
+        Index of the negative peak.
+
+    Returns
+    -------
+    float
+        The absolute field distance between the two peaks.
+    """
+
+    return float(abs(field[pos_idx] - field[neg_idx]))
+
+
 def fit_lorentzian_derivative(
     field: np.ndarray,
     intensity: np.ndarray,

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -18,7 +18,12 @@ import numpy as np
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.widgets import SpanSelector
 
-from .analysis import calc_fwhm, find_peak, fit_lorentzian_derivative
+from .analysis import (
+    calc_fwhm,
+    find_peak,
+    fit_lorentzian_derivative,
+    calc_peak_to_peak,
+)
 from .io import ESRLoader
 
 
@@ -48,6 +53,11 @@ class SpanPeakSelector:
         self.fit_btn: tk.Button | None = None
         self.peak_slider: tk.Scale | None = None
         self.selected_peak: float | None = None
+        self.pos_peak_slider: tk.Scale | None = None
+        self.neg_peak_slider: tk.Scale | None = None
+        self.pos_peak: float | None = None
+        self.neg_peak: float | None = None
+        self.dhpp_btn: tk.Button | None = None
         self.selector: SpanSelector | None = None
 
     # ------------------------------------------------------------------
@@ -123,6 +133,56 @@ class SpanPeakSelector:
             self.selected_peak = float(value)
         except ValueError:
             self.selected_peak = None
+
+    def _update_pos_peak(self, value: str) -> None:
+        """Store the user-chosen position of the positive peak."""
+
+        try:
+            self.pos_peak = float(value)
+        except ValueError:
+            self.pos_peak = None
+
+    def _update_neg_peak(self, value: str) -> None:
+        """Store the user-chosen position of the negative peak."""
+
+        try:
+            self.neg_peak = float(value)
+        except ValueError:
+            self.neg_peak = None
+
+    # ------------------------------------------------------------------
+    def analyse_peak_to_peak(self) -> None:
+        r"""Determine :math:`\Delta H_{pp}` using the peak sliders."""
+
+        if self.pos_peak is None or self.neg_peak is None:
+            messagebox.showwarning("Peak analysis", "Select both peaks")
+            return
+
+        field = self.spectrum.field
+        intensity = self.spectrum.intensity
+        pos_idx = int(np.abs(field - self.pos_peak).argmin())
+        neg_idx = int(np.abs(field - self.neg_peak).argmin())
+        dhpp = calc_peak_to_peak(field, intensity, pos_idx, neg_idx)
+
+        pos_field = field[pos_idx]
+        pos_y = intensity[pos_idx]
+        neg_field = field[neg_idx]
+        neg_y = intensity[neg_idx]
+
+        if self.tree is not None:
+            self.tree.insert(
+                "",
+                tk.END,
+                values=(
+                    f"{pos_field:.3f}",
+                    f"{pos_y:.3f}",
+                    f"{neg_field:.3f}",
+                    f"{neg_y:.3f}",
+                    f"{dhpp:.3f}",
+                ),
+            )
+
+        messagebox.showinfo("Peak analysis", f"\u0394H_pp={dhpp:.3f}")
 
     # ------------------------------------------------------------------
     def _fit_lorentzian(self) -> None:
@@ -223,6 +283,36 @@ class SpanPeakSelector:
 
         field_min = float(np.min(self.spectrum.field))
         field_max = float(np.max(self.spectrum.field))
+
+        self.pos_peak_slider = tk.Scale(
+            panel,
+            from_=field_min,
+            to=field_max,
+            orient=tk.HORIZONTAL,
+            label="Pos peak",
+            command=self._update_pos_peak,
+        )
+        self.pos_peak_slider.set(field_min)
+        self.pos_peak = field_min
+        self.pos_peak_slider.pack(fill=tk.X, padx=5, pady=5)
+
+        self.neg_peak_slider = tk.Scale(
+            panel,
+            from_=field_min,
+            to=field_max,
+            orient=tk.HORIZONTAL,
+            label="Neg peak",
+            command=self._update_neg_peak,
+        )
+        self.neg_peak_slider.set(field_max)
+        self.neg_peak = field_max
+        self.neg_peak_slider.pack(fill=tk.X, padx=5, pady=5)
+
+        self.dhpp_btn = tk.Button(
+            panel, text="Analyse \u0394H_pp", command=self.analyse_peak_to_peak
+        )
+        self.dhpp_btn.pack(padx=5, pady=5)
+
         self.peak_slider = tk.Scale(
             panel,
             from_=field_min,

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,7 +1,12 @@
 import numpy as np
 import pytest
 
-from esr_lab import find_peak, calc_fwhm, fit_lorentzian_derivative
+from esr_lab import (
+    find_peak,
+    calc_fwhm,
+    fit_lorentzian_derivative,
+    calc_peak_to_peak,
+)
 
 
 def test_find_peak_pair():
@@ -20,6 +25,16 @@ def test_calc_fwhm_from_peaks():
 
     pos_idx, neg_idx = find_peak(field, intensity, -2, 2)
     width = calc_fwhm(field, intensity, pos_idx, neg_idx)
+
+    assert np.isclose(width, 2.0, atol=1e-3)
+
+
+def test_calc_peak_to_peak_from_peaks():
+    field = np.linspace(-5, 5, 10001)
+    intensity = field * np.exp(-field**2 / 2)
+
+    pos_idx, neg_idx = find_peak(field, intensity, -2, 2)
+    width = calc_peak_to_peak(field, intensity, pos_idx, neg_idx)
 
     assert np.isclose(width, 2.0, atol=1e-3)
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -41,6 +41,19 @@ def test_span_selector_analysis():
         info.assert_called_once()
 
 
+def test_peak_to_peak_slider_analysis():
+    spectrum = ESRSpectrum(field=np.arange(5.0), intensity=np.zeros(5))
+    selector = gui.SpanPeakSelector(spectrum)
+    selector.pos_peak = 1.0
+    selector.neg_peak = 3.0
+
+    with patch("esr_lab.gui.calc_peak_to_peak", return_value=2.0) as cpp, \
+        patch("esr_lab.gui.messagebox.showinfo") as info:
+        selector.analyse_peak_to_peak()
+        cpp.assert_called_once()
+        info.assert_called_once()
+
+
 def test_lorentzian_fit_overlay():
     spectrum = ESRSpectrum(field=np.linspace(-1, 1, 5), intensity=np.zeros(5))
     selector = gui.SpanPeakSelector(spectrum)


### PR DESCRIPTION
## Summary
- Add `calc_peak_to_peak` for computing ΔH_pp linewidths
- Extend GUI with sliders and button to capture peaks and report ΔH_pp
- Cover new functionality with analysis and GUI tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adfec505a08324b225f59025a35fba