### PR TITLE
Display ESR metadata in analysis panel

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -265,6 +265,30 @@ class SpanPeakSelector:
         panel = tk.Frame(self.root)
         panel.pack(side=tk.RIGHT, fill=tk.Y)
 
+        # Show acquisition metadata at the top of the analysis panel
+        if self.spectrum.metadata:
+            meta = self.spectrum.metadata
+            lines: list[str] = []
+            if (freq := meta.get("Frequency")) is not None:
+                lines.append(f"Frequency: {freq}")
+            if (mod := meta.get("Modulation")) is not None:
+                lines.append(f"Modulation: {mod}")
+            if (mod_f := meta.get("ModulationFreq")) is not None:
+                lines.append(f"Mod. Freq.: {mod_f}")
+            if (b_from := meta.get("Bfrom")) is not None and (
+                b_to := meta.get("Bto")
+            ) is not None:
+                lines.append(f"B Sweep: {b_from}-{b_to}")
+            if (mw := meta.get("MicrowavePower")) is not None:
+                lines.append(f"MW Power: {mw}")
+            if (st := meta.get("SweepTime")) is not None:
+                lines.append(f"Sweep Time: {st}")
+            if (temp := meta.get("Temperature")) is not None:
+                lines.append(f"Temperature: {temp}")
+            if lines:
+                meta_label = tk.Label(panel, text="\n".join(lines), justify=tk.LEFT)
+                meta_label.pack(padx=5, pady=5)
+
         fig, self.ax = plt.subplots()
         self.ax.plot(self.spectrum.field, self.spectrum.intensity)
         self.ax.set_xlabel("Magnetic Field")

--- a/esr_lab/io.py
+++ b/esr_lab/io.py
@@ -37,12 +37,24 @@ class ESRLoader:
         with path.open("r", encoding="utf-8-sig") as f:
             lines = f.readlines()
 
-        # Find the beginning of the measurement block.
+        # Find the beginning of the measurement block and collect metadata
+        # lines appearing before it.
         data_start = None
+        metadata: dict[str, object] = {}
         for idx, line in enumerate(lines):
-            if line.strip().startswith("BField"):
+            stripped = line.strip()
+            if stripped.startswith("BField"):
                 data_start = idx
                 break
+            # Parse simple ``key;value`` pairs from the header
+            parts = [p.strip() for p in stripped.split(";")]
+            if len(parts) >= 2 and parts[0]:
+                key, value = parts[0], parts[1]
+                try:
+                    value = float(value)
+                except ValueError:
+                    pass
+                metadata[key] = value
 
         if data_start is not None:
             # Parse only the measurement block using a fixed semicolon
@@ -64,5 +76,7 @@ class ESRLoader:
         df = df.iloc[:, :2].copy()
         df.columns = ["BField [mT]", "MW_Absorption []"]
 
-        return ESRSpectrum.from_dataframe(df)
+        return ESRSpectrum.from_dataframe(
+            df, metadata=metadata if metadata else None
+        )
 

--- a/esr_lab/spectrum.py
+++ b/esr_lab/spectrum.py
@@ -28,14 +28,24 @@ class ESRSpectrum:
     metadata: Optional[Dict[str, Any]] = field(default=None)
 
     @classmethod
-    def from_dataframe(cls, df: pd.DataFrame) -> "ESRSpectrum":
+    def from_dataframe(
+        cls, df: pd.DataFrame, metadata: Optional[Dict[str, Any]] = None
+    ) -> "ESRSpectrum":
         """Create a spectrum from a pandas DataFrame.
 
         The DataFrame is expected to have at least two columns where the
         first column contains the magnetic field values and the second column
         the corresponding intensity.
+
+        Parameters
+        ----------
+        df:
+            Data frame with field values in the first column and intensity in
+            the second column.
+        metadata:
+            Optional metadata dictionary to attach to the resulting spectrum.
         """
 
         field_vals = df.iloc[:, 0].to_numpy()
         intensity_vals = df.iloc[:, 1].to_numpy()
-        return cls(field=field_vals, intensity=intensity_vals)
+        return cls(field=field_vals, intensity=intensity_vals, metadata=metadata)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -22,9 +22,27 @@ def test_load_csv_semicolon(tmp_path):
 def test_load_csv_with_metadata(tmp_path):
     csv_file = tmp_path / "data.csv"
     csv_file.write_text(
-        "Name;Test\n\nMeas\nBField [mT];MW_Absorption []\n1;2\n"
+        "Frequency;9.5\n"
+        "Modulation;0.2\n"
+        "ModulationFreq;100\n"
+        "Bfrom;0\n"
+        "Bto;10\n"
+        "MicrowavePower;5\n"
+        "SweepTime;60\n"
+        "Temperature;300\n"
+        "\nMeas\nBField [mT];MW_Absorption []\n1;2\n"
     )
 
     spectrum = ESRLoader.load_csv(csv_file)
     assert spectrum.field.tolist() == [1]
     assert spectrum.intensity.tolist() == [2]
+    assert spectrum.metadata == {
+        "Frequency": 9.5,
+        "Modulation": 0.2,
+        "ModulationFreq": 100.0,
+        "Bfrom": 0.0,
+        "Bto": 10.0,
+        "MicrowavePower": 5.0,
+        "SweepTime": 60.0,
+        "Temperature": 300.0,
+    }


### PR DESCRIPTION
## Summary
- Parse acquisition metadata from ESR CSV headers and attach it to `ESRSpectrum`
- Show frequency, modulation, sweep info and other metadata at the top of the analysis panel
- Extend tests to verify metadata extraction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae016c4d4c832481756a9ddbceec16