### PR TITLE
Remove axis range sliders from subplot configuration

### DIFF
--- a/esr_lab/plotter.py
+++ b/esr_lab/plotter.py
@@ -60,8 +60,6 @@ def configure_subplot(
     y_label: Optional[str] = None,
     title: Optional[str] = None,
     font_size: Optional[float] = None,
-    x_range: Optional[Tuple[float, float]] = None,
-    y_range: Optional[Tuple[float, float]] = None,
     x_ticks: Optional[Sequence[float]] = None,
     y_ticks: Optional[Sequence[float]] = None,
 ) -> None:
@@ -82,8 +80,6 @@ def configure_subplot(
         Axis and figure titles.
     font_size:
         Font size for axis labels, tick labels and the title.
-    x_range, y_range:
-        Two-tuples specifying the visible axis range.
     x_ticks, y_ticks:
         Explicit tick locations for the respective axes.
     """
@@ -109,12 +105,6 @@ def configure_subplot(
     if font_size is not None:
         for label in ax.get_xticklabels() + ax.get_yticklabels():
             label.set_fontsize(font_size)
-
-    # Axis ranges --------------------------------------------------------
-    if x_range is not None:
-        ax.set_xlim(x_range)
-    if y_range is not None:
-        ax.set_ylim(y_range)
 
     # Tick marks ---------------------------------------------------------
     if x_ticks is not None:

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -57,8 +57,6 @@ def test_configure_subplot_allows_customisation():
         y_label="Y axis",
         title="Title",
         font_size=14,
-        x_range=(0, 2),
-        y_range=(1, 3),
         x_ticks=[0, 1, 2],
         y_ticks=[1, 2, 3],
     )
@@ -70,8 +68,6 @@ def test_configure_subplot_allows_customisation():
     assert ax.get_xlabel() == "X axis"
     assert ax.get_ylabel() == "Y axis"
     assert ax.get_title() == "Title"
-    assert tuple(ax.get_xlim()) == (0, 2)
-    assert tuple(ax.get_ylim()) == (1, 3)
     assert list(ax.get_xticks()) == [0, 1, 2]
     assert list(ax.get_yticks()) == [1, 2, 3]
     assert ax.xaxis.label.get_fontsize() == 14


### PR DESCRIPTION
## Summary
- Simplify subplot configuration to rely on matplotlib defaults for axis ranges
- Update subplot configuration test to match new API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae046cfb988324a2d86d4c0a531a0c