### PR TITLE
Remove subplot configuration slider

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -28,6 +28,21 @@ from .analysis import (
 from .io import ESRLoader
 
 
+class NavigationToolbarNoSubplots(NavigationToolbar2Tk):
+    """Tk toolbar without the subplot configuration tool.
+
+    The default Matplotlib toolbar includes a *Configure Subplots* button which
+    launches a dialog with sliders for adjusting subplot parameters.  The
+    application does not rely on this functionality and its presence spawns an
+    unnecessary window.  A small subclass of ``NavigationToolbar2Tk`` removes the
+    corresponding tool so that users are left with the standard navigation
+    controls (home, pan, zoom, save) only.
+    """
+
+    # Filter out the "Subplots" entry from the base class' tool items.
+    toolitems = [item for item in NavigationToolbar2Tk.toolitems if item[0] != "Subplots"]
+
+
 class SpanPeakSelector:
     """Interactive peak analysis with an optional Tk GUI.
 
@@ -286,7 +301,7 @@ class SpanPeakSelector:
         self.ax.set_ylabel("Intensity")
         canvas = FigureCanvasTkAgg(fig, master=plot_frame)
         canvas.draw()
-        toolbar = NavigationToolbar2Tk(canvas, plot_frame, pack_toolbar=False)
+        toolbar = NavigationToolbarNoSubplots(canvas, plot_frame, pack_toolbar=False)
         toolbar.update()
         canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
         toolbar.pack(side=tk.BOTTOM, fill=tk.X)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -104,3 +104,9 @@ def test_lorentzian_fit_overlay():
         assert len(selector.ax.lines) == 1
     plt.close(fig)
 
+
+def test_toolbar_has_default_tools_without_subplots():
+    tools = [item[0] for item in gui.NavigationToolbarNoSubplots.toolitems if item]
+    assert "Subplots" not in tools
+    assert "Pan" in tools and "Zoom" in tools
+


### PR DESCRIPTION
## Summary
- Replace Matplotlib toolbar with a subclass omitting the *Configure Subplots* button to prevent the slider dialog from appearing.
- Update GUI to use the new toolbar and ensure standard navigation tools remain.
- Add regression test verifying the toolbar lacks the subplot tool while retaining pan/zoom.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae06ed4a2c8324a8af7b2ce5b3ab85