### PR TITLE
Preserve analysis results across runs

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -82,15 +82,22 @@ class SpanPeakSelector:
         analysis_func: Callable[[np.ndarray, np.ndarray, int, int], float] = calc_fwhm,
         label: str = "FWHM",
     ) -> None:
-        """Enable span selection and prepare for analysis."""
+        """Enable span selection and prepare for analysis.
 
-        if self.tree is not None:
-            for row in self.tree.get_children():
-                self.tree.delete(row)
-            if "width" in self.tree["columns"]:
-                self.tree.heading("width", text=label)
+        Previously this method cleared any existing analysis results each time a
+        new analysis was started.  This behaviour made it impossible to perform
+        multiple analyses in succession without losing earlier data.  The method
+        now preserves ``self.results`` and any existing table entries so that
+        users can accumulate measurements across different analyses.
+        """
+
+        if self.tree is not None and "width" in self.tree["columns"]:
+            # The tree keeps previously analysed data; only the analysis label
+            # column distinguishes between different result types so the width
+            # heading can remain unchanged.
+            pass
+
         self.ranges.clear()
-        self.results.clear()
         self.analysis_func = analysis_func
         self.analysis_label = label
         if self.selector is not None:
@@ -345,7 +352,10 @@ class SpanPeakSelector:
             "pos_y": "Pos Y",
             "neg_x": "Neg X",
             "neg_y": "Neg Y",
-            "width": self.analysis_label,
+            # The value column holds either FWHM or ΔH_pp results depending on
+            # the active analysis.  Keeping a generic heading allows appending
+            # results from multiple analyses without clearing the table.
+            "width": "Value",
         }
         for col, text in headings.items():
             self.tree.heading(col, text=text)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -77,6 +77,43 @@ def test_peak_to_peak_analysis():
     plt.close(fig)
 
 
+def test_results_persist_across_analyses():
+    spectrum = ESRSpectrum(field=np.arange(5.0), intensity=np.zeros(5))
+    selector = gui.SpanPeakSelector(spectrum)
+    fig, selector.ax = plt.subplots()
+
+    with patch("esr_lab.gui.find_peak", return_value=(1, 3)) as fp, \
+        patch("esr_lab.gui.calc_fwhm", return_value=0.5) as cf, \
+        patch("esr_lab.gui.calc_peak_to_peak", return_value=2.0) as cpp, \
+        patch("esr_lab.gui.messagebox.showinfo"):
+        selector.start_analysis(analysis_func=cf)
+        selector.onselect(1.0, 2.0)
+        selector.start_peak_to_peak()
+        selector.onselect(0.0, 4.0)
+        assert fp.call_count == 2
+        cf.assert_called_once()
+        cpp.assert_called_once()
+        assert selector.results == [
+            {
+                "analysis": "FWHM",
+                "pos_x": 1.0,
+                "pos_y": 0.0,
+                "neg_x": 3.0,
+                "neg_y": 0.0,
+                "width": 0.5,
+            },
+            {
+                "analysis": "\u0394H_pp",
+                "pos_x": 1.0,
+                "pos_y": 0.0,
+                "neg_x": 3.0,
+                "neg_y": 0.0,
+                "width": 2.0,
+            },
+        ]
+    plt.close(fig)
+
+
 def test_lorentzian_fit_overlay():
     spectrum = ESRSpectrum(field=np.linspace(-1, 1, 5), intensity=np.zeros(5))
     selector = gui.SpanPeakSelector(spectrum)


### PR DESCRIPTION
## Summary
- Keep previously computed peaks when starting a new analysis
- Use a generic value column heading so FWHM and ΔH_pp results accumulate in one table
- Add regression test for persistent analysis results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae091a2df08324bfa6340c8ec01c84