### PR TITLE
Add Lorentzian fit results table

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -172,6 +172,7 @@ class SpanPeakSelector:
         self.root: tk.Tk | None = None
         self.ax = None
         self.tree: ttk.Treeview | None = None
+        self.lorentz_tree: ttk.Treeview | None = None
         self.analyse_btn: tk.Button | None = None
         self.dhpp_btn: tk.Button | None = None
         self.fit_btn: tk.Button | None = None
@@ -182,6 +183,7 @@ class SpanPeakSelector:
         self.analysis_label: str = "FWHM"
         # Store analysed peak data for optional export
         self.results: list[dict[str, float | str]] = []
+        self.lorentz_results: list[dict[str, float]] = []
 
     # ------------------------------------------------------------------
     def start_analysis(
@@ -353,6 +355,28 @@ class SpanPeakSelector:
         if not accept:
             line.remove()
             self.ax.figure.canvas.draw_idle()
+            return
+
+        result = {
+            "peak": float(self.selected_peak),
+            "h_res": float(h_res),
+            "delta": float(delta),
+            "A": float(A),
+            "B": float(B),
+        }
+        self.lorentz_results.append(result)
+        if self.lorentz_tree is not None:
+            self.lorentz_tree.insert(
+                "",
+                tk.END,
+                values=(
+                    f"{self.selected_peak:.3f}",
+                    f"{h_res:.3f}",
+                    f"{delta:.3f}",
+                    f"{A:.3f}",
+                    f"{B:.3f}",
+                ),
+            )
 
     def fit_lorentzian(self) -> None:
         """Fit the Lorentzian model to the peak chosen via the slider."""
@@ -467,6 +491,21 @@ class SpanPeakSelector:
         for col, text in headings.items():
             self.tree.heading(col, text=text)
         self.tree.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        lorentz_columns = ("peak", "h_res", "delta", "A", "B")
+        self.lorentz_tree = ttk.Treeview(
+            panel, columns=lorentz_columns, show="headings", height=5
+        )
+        lorentz_headings = {
+            "peak": "Peak",
+            "h_res": "H_res",
+            "delta": "Delta",
+            "A": "A",
+            "B": "B",
+        }
+        for col, text in lorentz_headings.items():
+            self.lorentz_tree.heading(col, text=text)
+        self.lorentz_tree.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
 
         self.root.mainloop()
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from esr_lab import gui
 from esr_lab.spectrum import ESRSpectrum
@@ -139,6 +139,26 @@ def test_lorentzian_fit_overlay():
         fit.assert_called_once()
         ask.assert_called_once()
         assert len(selector.ax.lines) == 1
+    plt.close(fig)
+
+
+def test_lorentzian_fit_results_tabulated():
+    spectrum = ESRSpectrum(field=np.linspace(-1, 1, 5), intensity=np.zeros(5))
+    selector = gui.SpanPeakSelector(spectrum)
+    fig, selector.ax = plt.subplots()
+    selector.ax.plot(spectrum.field, spectrum.intensity)
+    selector.selected_peak = 0.0
+    selector.lorentz_tree = MagicMock()
+    with patch(
+        "esr_lab.gui.fit_lorentzian_derivative",
+        return_value=(0.0, 1.0, 2.0, 3.0),
+    ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=True):
+        selector.fit_lorentzian()
+        fit.assert_called_once()
+    assert selector.lorentz_results == [
+        {"peak": 0.0, "h_res": 0.0, "delta": 1.0, "A": 2.0, "B": 3.0}
+    ]
+    selector.lorentz_tree.insert.assert_called_once()
     plt.close(fig)
 
 


### PR DESCRIPTION
## Summary
- add dedicated table in analysis panel to store Lorentzian fit parameters
- persist Lorentzian fit parameters in `SpanPeakSelector`
- test Lorentzian tabulation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0bad7cb08324826d2c88ed873281