### PR TITLE
Ensure plot edit dialog respects axis limits

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -28,6 +28,12 @@ from .analysis import (
 from .io import ESRLoader
 
 
+def _filter_ticks(ticks: list[float], lower: float, upper: float) -> list[float]:
+    """Return only tick locations within the provided axis limits."""
+
+    return [t for t in ticks if lower <= t <= upper]
+
+
 class NavigationToolbarNoSubplots(NavigationToolbar2Tk):
     """Tk toolbar without the subplot configuration tool.
 
@@ -110,13 +116,19 @@ class NavigationToolbarNoSubplots(NavigationToolbar2Tk):
 
         def apply() -> None:
             try:
-                ax.set_xlim(float(xmin_ent.get()), float(xmax_ent.get()))
+                xmin_val = float(xmin_ent.get())
+                xmax_val = float(xmax_ent.get())
+                ax.set_xlim(xmin_val, xmax_val)
+                xmin_val, xmax_val = ax.get_xlim()
             except ValueError:
-                pass
+                xmin_val, xmax_val = ax.get_xlim()
             try:
-                ax.set_ylim(float(ymin_ent.get()), float(ymax_ent.get()))
+                ymin_val = float(ymin_ent.get())
+                ymax_val = float(ymax_ent.get())
+                ax.set_ylim(ymin_val, ymax_val)
+                ymin_val, ymax_val = ax.get_ylim()
             except ValueError:
-                pass
+                ymin_val, ymax_val = ax.get_ylim()
 
             ax.set_title(title_ent.get())
             ax.set_xlabel(xlabel_ent.get())
@@ -134,11 +146,13 @@ class NavigationToolbarNoSubplots(NavigationToolbar2Tk):
 
             try:
                 ticks = [float(v) for v in xticks_ent.get().split(",") if v.strip()]
+                ticks = _filter_ticks(ticks, xmin_val, xmax_val)
                 ax.set_xticks(ticks)
             except ValueError:
                 pass
             try:
                 ticks = [float(v) for v in yticks_ent.get().split(",") if v.strip()]
+                ticks = _filter_ticks(ticks, ymin_val, ymax_val)
                 ax.set_yticks(ticks)
             except ValueError:
                 pass

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -168,3 +168,14 @@ def test_toolbar_has_default_tools_without_subplots():
     assert "Pan" in tools and "Zoom" in tools
     assert "Edit" in tools
 
+
+def test_filter_ticks_respects_limits():
+    fig, ax = plt.subplots()
+    ax.set_xlim(0, 10)
+    ax.set_xticks(gui._filter_ticks([-50, 0, 10], 0, 10))
+    ax.set_ylim(0, 1)
+    ax.set_yticks(gui._filter_ticks([-1, 0, 1], 0, 1))
+    assert ax.get_xlim() == (0.0, 10.0)
+    assert ax.get_ylim() == (0.0, 1.0)
+    plt.close(fig)
+


### PR DESCRIPTION
## Summary
- prevent tick inputs outside new x/y limits from forcing autoscaling
- add helper to filter ticks and apply filtered ticks in edit dialog
- add regression test for tick filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0d211608832497527d95dd94754c