### PR TITLE
Center values in analysis tables

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -504,6 +504,8 @@ class SpanPeakSelector:
         }
         for col, text in headings.items():
             self.tree.heading(col, text=text)
+            # Center values in each column for improved readability
+            self.tree.column(col, anchor=tk.CENTER)
         self.tree.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
 
         lorentz_columns = ("peak", "h_res", "delta", "A", "B")
@@ -519,6 +521,8 @@ class SpanPeakSelector:
         }
         for col, text in lorentz_headings.items():
             self.lorentz_tree.heading(col, text=text)
+            # Center Lorentzian fit results to keep the table consistent
+            self.lorentz_tree.column(col, anchor=tk.CENTER)
         self.lorentz_tree.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
 
         self.root.mainloop()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -179,3 +179,48 @@ def test_filter_ticks_respects_limits():
     assert ax.get_ylim() == (0.0, 1.0)
     plt.close(fig)
 
+
+def test_table_columns_centered(monkeypatch):
+    """Ensure tabulated values are centred for readability."""
+
+    spectrum = ESRSpectrum(field=np.linspace(-1, 1, 5), intensity=np.zeros(5))
+    selector = gui.SpanPeakSelector(spectrum)
+
+    column_cfg: dict[str, dict] = {}
+
+    class DummyTree:
+        def heading(self, *args, **kwargs):
+            pass
+
+        def column(self, col, **cfg):
+            column_cfg[col] = cfg
+
+        def pack(self, *args, **kwargs):
+            pass
+
+    class DummyFrame:
+        def pack(self, *args, **kwargs):
+            pass
+
+    class DummyTk:
+        def title(self, *args, **kwargs):
+            pass
+
+        def mainloop(self):
+            pass
+
+    monkeypatch.setattr(gui.tk, "Tk", lambda: DummyTk())
+    monkeypatch.setattr(gui.tk, "Frame", lambda *a, **k: DummyFrame())
+    monkeypatch.setattr(gui.tk, "Button", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(gui.tk, "Scale", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(gui.tk, "Label", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(gui.ttk, "Treeview", lambda *a, **k: DummyTree())
+    monkeypatch.setattr(gui, "FigureCanvasTkAgg", MagicMock())
+    monkeypatch.setattr(gui, "NavigationToolbarNoSubplots", MagicMock())
+
+    selector.show()
+
+    # All columns created in show should be centred
+    assert column_cfg
+    assert all(cfg.get("anchor") == gui.tk.CENTER for cfg in column_cfg.values())
+


### PR DESCRIPTION
## Summary
- Center values in ESR analysis and Lorentzian fit tables for improved readability
- Add regression test confirming table columns are centered

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0e431f2c8324858ea4e5a2d30964