### PR TITLE
feat: expand plot customization

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -102,17 +102,31 @@ class NavigationToolbarNoSubplots(NavigationToolbar2Tk):
         lw_init = ax.lines[0].get_linewidth() if ax.lines else 1.0
         lw_ent = add_entry(7, "Line width", f"{lw_init}")
 
+        color_init = ax.lines[0].get_color() if ax.lines else ""
+        color_ent = add_entry(8, "Line color", color_init)
+
+        tk.Label(dialog, text="Marker").grid(row=9, column=0, sticky="e")
+        marker_init = ax.lines[0].get_marker() if ax.lines else "None"
+        marker_var = tk.StringVar(value=marker_init)
+        markers = ["None", "o", "s", "^", "D", "*", "x", "+"]
+        tk.OptionMenu(dialog, marker_var, *markers).grid(row=9, column=1, sticky="w")
+
         # Scale selection
-        tk.Label(dialog, text="X scale").grid(row=8, column=0, sticky="e")
+        tk.Label(dialog, text="X scale").grid(row=10, column=0, sticky="e")
         xscale_var = tk.StringVar(value=ax.get_xscale())
-        tk.OptionMenu(dialog, xscale_var, "linear", "log").grid(row=8, column=1, sticky="w")
+        tk.OptionMenu(dialog, xscale_var, "linear", "log").grid(row=10, column=1, sticky="w")
 
-        tk.Label(dialog, text="Y scale").grid(row=9, column=0, sticky="e")
+        tk.Label(dialog, text="Y scale").grid(row=11, column=0, sticky="e")
         yscale_var = tk.StringVar(value=ax.get_yscale())
-        tk.OptionMenu(dialog, yscale_var, "linear", "log").grid(row=9, column=1, sticky="w")
+        tk.OptionMenu(dialog, yscale_var, "linear", "log").grid(row=11, column=1, sticky="w")
 
-        xticks_ent = add_entry(10, "X ticks", ", ".join(map(str, ax.get_xticks())))
-        yticks_ent = add_entry(11, "Y ticks", ", ".join(map(str, ax.get_yticks())))
+        xticks_ent = add_entry(12, "X ticks", ", ".join(map(str, ax.get_xticks())))
+        yticks_ent = add_entry(13, "Y ticks", ", ".join(map(str, ax.get_yticks())))
+
+        major_var = tk.BooleanVar(value=ax.xaxis._major_tick_kw.get("gridOn", False))
+        tk.Checkbutton(dialog, text="Major grid", variable=major_var).grid(row=14, column=0, columnspan=2, sticky="w")
+        minor_var = tk.BooleanVar(value=ax.xaxis._minor_tick_kw.get("gridOn", False))
+        tk.Checkbutton(dialog, text="Minor grid", variable=minor_var).grid(row=15, column=0, columnspan=2, sticky="w")
 
         def apply() -> None:
             try:
@@ -141,6 +155,15 @@ class NavigationToolbarNoSubplots(NavigationToolbar2Tk):
             except ValueError:
                 pass
 
+            color_val = color_ent.get().strip()
+            if color_val:
+                for line in ax.lines:
+                    line.set_color(color_val)
+
+            marker_val = marker_var.get()
+            for line in ax.lines:
+                line.set_marker("" if marker_val == "None" else marker_val)
+
             ax.set_xscale(xscale_var.get())
             ax.set_yscale(yscale_var.get())
 
@@ -157,10 +180,17 @@ class NavigationToolbarNoSubplots(NavigationToolbar2Tk):
             except ValueError:
                 pass
 
+            ax.grid(major_var.get(), which="major")
+            if minor_var.get():
+                ax.minorticks_on()
+            else:
+                ax.minorticks_off()
+            ax.grid(minor_var.get(), which="minor")
+
             self.canvas.draw_idle()
             dialog.destroy()
 
-        tk.Button(dialog, text="Apply", command=apply).grid(row=12, column=0, columnspan=2, pady=5)
+        tk.Button(dialog, text="Apply", command=apply).grid(row=16, column=0, columnspan=2, pady=5)
 
 
 

--- a/esr_lab/plotter.py
+++ b/esr_lab/plotter.py
@@ -62,6 +62,8 @@ def configure_subplot(
     font_size: Optional[float] = None,
     x_ticks: Optional[Sequence[float]] = None,
     y_ticks: Optional[Sequence[float]] = None,
+    major_grid: Optional[bool] = None,
+    minor_grid: Optional[bool] = None,
 ) -> None:
     """Configure common display properties of a Matplotlib subplot.
 
@@ -82,6 +84,8 @@ def configure_subplot(
         Font size for axis labels, tick labels and the title.
     x_ticks, y_ticks:
         Explicit tick locations for the respective axes.
+    major_grid, minor_grid:
+        Toggle visibility of major and minor grid lines.
     """
 
     # Line styling -------------------------------------------------------
@@ -111,3 +115,11 @@ def configure_subplot(
         ax.set_xticks(list(x_ticks))
     if y_ticks is not None:
         ax.set_yticks(list(y_ticks))
+
+    # Grid lines ---------------------------------------------------------
+    if major_grid is not None:
+        ax.grid(major_grid, which="major")
+    if minor_grid is not None:
+        if minor_grid:
+            ax.minorticks_on()
+        ax.grid(minor_grid, which="minor")

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -59,6 +59,8 @@ def test_configure_subplot_allows_customisation():
         font_size=14,
         x_ticks=[0, 1, 2],
         y_ticks=[1, 2, 3],
+        major_grid=True,
+        minor_grid=True,
     )
 
     line = ax.lines[0]
@@ -73,4 +75,6 @@ def test_configure_subplot_allows_customisation():
     assert ax.xaxis.label.get_fontsize() == 14
     assert ax.yaxis.label.get_fontsize() == 14
     assert ax.title.get_fontsize() == 14
+    assert ax.xaxis._major_tick_kw["gridOn"]
+    assert ax.xaxis._minor_tick_kw["gridOn"]
     plt.close(fig)


### PR DESCRIPTION
## Summary
- allow plotter.configure_subplot to toggle major and minor grids
- expose line color, marker style, and grid controls in the GUI edit dialog
- test grid configuration in configure_subplot

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae10055dec832484b1e0501793e405