### PR TITLE
Keep edit plot dialog open after applying color changes

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -214,9 +214,9 @@ class NavigationToolbarNoSubplots(NavigationToolbar2Tk):
             ax.grid(minor_var.get(), which="minor")
 
             self.canvas.draw_idle()
-            dialog.destroy()
 
-        tk.Button(dialog, text="Apply", command=apply).grid(row=16, column=0, columnspan=2, pady=5)
+        tk.Button(dialog, text="Apply", command=apply).grid(row=16, column=0, pady=5)
+        tk.Button(dialog, text="Close", command=dialog.destroy).grid(row=16, column=1, pady=5)
 
 
 


### PR DESCRIPTION
## Summary
- avoid closing edit dialog when applying plot settings
- add a dedicated `Close` button to dismiss the dialog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae176591dc832495f322d4c3d0b763