### PR TITLE
Prompt peak selection for ESR analysis

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import tkinter as tk
-from tkinter import filedialog, messagebox, ttk, colorchooser
+from tkinter import filedialog, messagebox, ttk, colorchooser, simpledialog
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -273,10 +273,10 @@ class SpanPeakSelector:
         # Keep analysis results for each loaded spectrum separately.  ``results``
         # and ``lorentz_results`` always refer to the currently selected trace so
         # the public API remains unchanged.
-        self.results_all: list[list[dict[str, float | str]]] = [
+        self.results_all: list[list[dict[str, float | str | int]]] = [
             [] for _ in self.spectra
         ]
-        self.lorentz_all: list[list[dict[str, float]]] = [
+        self.lorentz_all: list[list[dict[str, float | str | int]]] = [
             [] for _ in self.spectra
         ]
         self.results = self.results_all[self.current]
@@ -302,9 +302,35 @@ class SpanPeakSelector:
         self.trace_var: tk.StringVar | None = None
         self.peak_slider: tk.Scale | None = None
         self.selected_peak: float | None = None
+        # Keep track of which peak (1 or 2) the user is analysing.
+        # Default to the first peak so headless usage remains functional
+        # without invoking the interactive prompt.
+        self.current_peak: int = 1
         self.selector: SpanSelector | None = None
         self.analysis_func: Callable[[np.ndarray, np.ndarray, int, int], float] = calc_fwhm
         self.analysis_label: str = "FWHM"
+
+    # ------------------------------------------------------------------
+    def _prompt_peak(self) -> int | None:
+        """Ask the user which peak should be analysed.
+
+        Returns
+        -------
+        int | None
+            ``1`` or ``2`` depending on the user's choice.  ``None`` is
+            returned if the dialog is cancelled.  In headless environments
+            where the dialog cannot be shown, the function falls back to
+            the first peak to keep scripted use working.
+        """
+
+        try:
+            return simpledialog.askinteger(
+                "Select Peak", "Analyse peak 1 or 2?", minvalue=1, maxvalue=2
+            )
+        except Exception:
+            # When running without a display (e.g. during tests) Tk may raise
+            # errors.  Defaulting to the first peak keeps the API usable.
+            return 1
 
     # ------------------------------------------------------------------
     def start_analysis(
@@ -326,6 +352,11 @@ class SpanPeakSelector:
             # column distinguishes between different result types so the width
             # heading can remain unchanged.
             pass
+
+        peak_choice = self._prompt_peak()
+        if peak_choice is None:
+            return
+        self.current_peak = int(peak_choice)
 
         self.ranges.clear()
         self.analysis_func = analysis_func
@@ -369,6 +400,7 @@ class SpanPeakSelector:
 
         result = {
             "analysis": self.analysis_label,
+            "peak": int(self.current_peak),
             "pos_x": float(pos_field),
             "pos_y": float(pos_y),
             "neg_x": float(neg_field),
@@ -383,6 +415,7 @@ class SpanPeakSelector:
                 tk.END,
                 values=(
                     self.analysis_label,
+                    f"{self.current_peak}",
                     f"{pos_field:.3f}",
                     f"{pos_y:.3f}",
                     f"{neg_field:.3f}",
@@ -392,7 +425,10 @@ class SpanPeakSelector:
             )
 
         lines = [
-            f"Absorption: pos={r['pos_x']:.3f}, neg={r['neg_x']:.3f}, {r['analysis']}={r['width']:.3f}"
+            (
+                f"Peak {r['peak']}: pos={r['pos_x']:.3f}, neg={r['neg_x']:.3f}, "
+                f"{r['analysis']}={r['width']:.3f}"
+            )
             for r in self.results
         ]
 
@@ -479,7 +515,8 @@ class SpanPeakSelector:
             return
 
         result = {
-            "peak": float(self.selected_peak),
+            "analysis": "Lorentzian",
+            "peak": int(self.current_peak),
             "h_res": float(h_res),
             "delta": float(delta),
             "A": float(A),
@@ -491,7 +528,8 @@ class SpanPeakSelector:
                 "",
                 tk.END,
                 values=(
-                    f"{self.selected_peak:.3f}",
+                    "Lorentzian",
+                    f"{self.current_peak}",
                     f"{h_res:.3f}",
                     f"{delta:.3f}",
                     f"{A:.3f}",
@@ -502,6 +540,10 @@ class SpanPeakSelector:
     def fit_lorentzian(self) -> None:
         """Fit the Lorentzian model to the peak chosen via the slider."""
 
+        peak_choice = self._prompt_peak()
+        if peak_choice is None:
+            return
+        self.current_peak = int(peak_choice)
         self._fit_lorentzian()
 
     # ------------------------------------------------------------------
@@ -530,6 +572,7 @@ class SpanPeakSelector:
                     tk.END,
                     values=(
                         r["analysis"],
+                        f"{r['peak']}",
                         f"{r['pos_x']:.3f}",
                         f"{r['pos_y']:.3f}",
                         f"{r['neg_x']:.3f}",
@@ -546,7 +589,8 @@ class SpanPeakSelector:
                     "",
                     tk.END,
                     values=(
-                        f"{r['peak']:.3f}",
+                        r["analysis"],
+                        f"{r['peak']}",
                         f"{r['h_res']:.3f}",
                         f"{r['delta']:.3f}",
                         f"{r['A']:.3f}",
@@ -679,10 +723,11 @@ class SpanPeakSelector:
         )
         self.fit_btn.pack(padx=5, pady=5)
 
-        columns = ("analysis", "pos_x", "pos_y", "neg_x", "neg_y", "width")
+        columns = ("analysis", "peak", "pos_x", "pos_y", "neg_x", "neg_y", "width")
         self.tree = ttk.Treeview(panel, columns=columns, show="headings", height=5)
         headings = {
             "analysis": "Analysis",
+            "peak": "Peak",
             "pos_x": "Pos X",
             "pos_y": "Pos Y",
             "neg_x": "Neg X",
@@ -698,11 +743,12 @@ class SpanPeakSelector:
             self.tree.column(col, anchor=tk.CENTER)
         self.tree.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
 
-        lorentz_columns = ("peak", "h_res", "delta", "A", "B")
+        lorentz_columns = ("analysis", "peak", "h_res", "delta", "A", "B")
         self.lorentz_tree = ttk.Treeview(
             panel, columns=lorentz_columns, show="headings", height=5
         )
         lorentz_headings = {
+            "analysis": "Analysis",
             "peak": "Peak",
             "h_res": "H_res",
             "delta": "Delta",

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -42,6 +42,7 @@ def test_span_selector_analysis():
         assert selector.results == [
             {
                 "analysis": "FWHM",
+                "peak": 1,
                 "pos_x": 1.0,
                 "pos_y": 0.0,
                 "neg_x": 3.0,
@@ -58,7 +59,8 @@ def test_peak_to_peak_analysis():
     fig, selector.ax = plt.subplots()
     with patch("esr_lab.gui.find_peak", return_value=(1, 3)) as fp, \
         patch("esr_lab.gui.calc_peak_to_peak", return_value=2.0) as cpp, \
-        patch("esr_lab.gui.messagebox.showinfo") as info:
+        patch("esr_lab.gui.messagebox.showinfo") as info, \
+        patch("esr_lab.gui.simpledialog.askinteger", return_value=1):
         selector.start_peak_to_peak()
         selector.onselect(0.0, 4.0)
         fp.assert_called_once()
@@ -67,6 +69,7 @@ def test_peak_to_peak_analysis():
         assert selector.results == [
             {
                 "analysis": "\u0394H_pp",
+                "peak": 1,
                 "pos_x": 1.0,
                 "pos_y": 0.0,
                 "neg_x": 3.0,
@@ -85,7 +88,8 @@ def test_results_persist_across_analyses():
     with patch("esr_lab.gui.find_peak", return_value=(1, 3)) as fp, \
         patch("esr_lab.gui.calc_fwhm", return_value=0.5) as cf, \
         patch("esr_lab.gui.calc_peak_to_peak", return_value=2.0) as cpp, \
-        patch("esr_lab.gui.messagebox.showinfo"):
+        patch("esr_lab.gui.messagebox.showinfo"), \
+        patch("esr_lab.gui.simpledialog.askinteger", return_value=1):
         selector.start_analysis(analysis_func=cf)
         selector.onselect(1.0, 2.0)
         selector.start_peak_to_peak()
@@ -96,6 +100,7 @@ def test_results_persist_across_analyses():
         assert selector.results == [
             {
                 "analysis": "FWHM",
+                "peak": 1,
                 "pos_x": 1.0,
                 "pos_y": 0.0,
                 "neg_x": 3.0,
@@ -104,6 +109,7 @@ def test_results_persist_across_analyses():
             },
             {
                 "analysis": "\u0394H_pp",
+                "peak": 1,
                 "pos_x": 1.0,
                 "pos_y": 0.0,
                 "neg_x": 3.0,
@@ -131,7 +137,8 @@ def test_multi_trace_results_isolated():
 
     with patch("esr_lab.gui.find_peak", return_value=(1, 3)), \
         patch("esr_lab.gui.calc_fwhm", return_value=0.5), \
-        patch("esr_lab.gui.messagebox.showinfo"):
+        patch("esr_lab.gui.messagebox.showinfo"), \
+        patch("esr_lab.gui.simpledialog.askinteger", return_value=1):
         selector.start_analysis()
         selector.onselect(1.0, 2.0)
 
@@ -154,7 +161,9 @@ def test_lorentzian_fit_overlay():
     selector.selected_peak = -0.5
     with patch(
         "esr_lab.gui.fit_lorentzian_derivative", return_value=(0.0, 1.0, 1.0, 0.0)
-    ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=True) as ask:
+    ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=True) as ask, patch(
+        "esr_lab.gui.simpledialog.askinteger", return_value=1
+    ):
         selector.fit_lorentzian()
         fit.assert_called_once()
         ask.assert_called_once()
@@ -166,7 +175,9 @@ def test_lorentzian_fit_overlay():
     selector.selected_peak = 0.5
     with patch(
         "esr_lab.gui.fit_lorentzian_derivative", return_value=(0.0, 1.0, 1.0, 0.0)
-    ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=False) as ask:
+    ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=False) as ask, patch(
+        "esr_lab.gui.simpledialog.askinteger", return_value=1
+    ):
         selector.fit_lorentzian()
         fit.assert_called_once()
         ask.assert_called_once()
@@ -184,11 +195,13 @@ def test_lorentzian_fit_results_tabulated():
     with patch(
         "esr_lab.gui.fit_lorentzian_derivative",
         return_value=(0.0, 1.0, 2.0, 3.0),
-    ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=True):
+    ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=True), patch(
+        "esr_lab.gui.simpledialog.askinteger", return_value=1
+    ):
         selector.fit_lorentzian()
         fit.assert_called_once()
     assert selector.lorentz_results == [
-        {"peak": 0.0, "h_res": 0.0, "delta": 1.0, "A": 2.0, "B": 3.0}
+        {"analysis": "Lorentzian", "peak": 1, "h_res": 0.0, "delta": 1.0, "A": 2.0, "B": 3.0}
     ]
     selector.lorentz_tree.insert.assert_called_once()
     plt.close(fig)


### PR DESCRIPTION
## Summary
- prompt users to choose peak 1 or 2 before running FWHM, ΔH_pp, or Lorentzian analyses
- track selected peak in results and display method/peak columns in analysis tables
- update Lorentzian fitting to honor peak choice and reflect it in tabulated output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae19f24210832488a84a03102f3770