### PR TITLE
Add automated peak finding to analysis panel

### DIFF
--- a/esr_lab/__init__.py
+++ b/esr_lab/__init__.py
@@ -8,6 +8,7 @@ from .analysis import (
     calc_fwhm,
     fit_lorentzian_derivative,
     calc_peak_to_peak,
+    peak_finder,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "calc_fwhm",
     "fit_lorentzian_derivative",
     "calc_peak_to_peak",
+    "peak_finder",
 ]

--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -119,6 +119,82 @@ def calc_peak_to_peak(
     return float(abs(field[pos_idx] - field[neg_idx]))
 
 
+def peak_finder(
+    field: np.ndarray, intensity: np.ndarray, expected: int = 4
+) -> list[tuple[int, int]]:
+    """Automatically locate peak pairs in the provided data.
+
+    Parameters
+    ----------
+    field:
+        Array of magnetic-field values.
+    intensity:
+        Array of recorded intensity values corresponding to ``field``.
+    expected:
+        Total number of extrema to locate.  This should be an even number as
+        each absorption line exhibits a positive and a negative extremum.  The
+        default of ``4`` therefore corresponds to two absorption lines.
+
+    Returns
+    -------
+    list[tuple[int, int]]
+        A list of ``(positive_idx, negative_idx)`` tuples ordered by increasing
+        field.  Each tuple represents one absorption line with the positive and
+        negative peaks chosen as the closest pair in magnetic field.
+
+    Raises
+    ------
+    ValueError
+        If an insufficient number of extrema is found or if ``expected`` is not
+        a positive, even integer.
+    """
+
+    if expected < 2 or expected % 2 != 0:
+        raise ValueError("Expected number of peaks must be an even integer >= 2")
+
+    pos_peaks, _ = find_peaks(intensity)
+    neg_peaks, _ = find_peaks(-intensity)
+
+    n_pairs = expected // 2
+    if len(pos_peaks) < n_pairs or len(neg_peaks) < n_pairs:
+        raise ValueError("Not enough peaks found in the data")
+
+    # Select the most prominent extrema first.
+    pos_order = np.argsort(intensity[pos_peaks])[-n_pairs:]
+    neg_order = np.argsort(intensity[neg_peaks])[:n_pairs]
+    pos_idx = pos_peaks[pos_order]
+    neg_idx = neg_peaks[neg_order]
+
+    # Determine pairs based on proximity in the magnetic field so that each
+    # positive/negative combination corresponds to a single absorption peak.
+    pos_fields = field[pos_idx]
+    neg_fields = field[neg_idx]
+    distances: list[tuple[float, int, int]] = []
+    for p_idx, p in enumerate(pos_idx):
+        for n_idx, n in enumerate(neg_idx):
+            dist = abs(pos_fields[p_idx] - neg_fields[n_idx])
+            distances.append((float(dist), int(p), int(n)))
+
+    distances.sort(key=lambda x: x[0])
+    used_pos: set[int] = set()
+    used_neg: set[int] = set()
+    pairs: list[tuple[int, int]] = []
+    for _dist, p, n in distances:
+        if p in used_pos or n in used_neg:
+            continue
+        pairs.append((p, n))
+        used_pos.add(p)
+        used_neg.add(n)
+        if len(pairs) == n_pairs:
+            break
+
+    if len(pairs) < n_pairs:
+        raise ValueError("Not enough distinct peak pairs found")
+
+    pairs.sort(key=lambda pr: min(field[pr[0]], field[pr[1]]))
+    return [(int(p), int(n)) for p, n in pairs]
+
+
 def fit_lorentzian_derivative(
     field: np.ndarray,
     intensity: np.ndarray,

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -24,6 +24,7 @@ from .analysis import (
     find_peak,
     fit_lorentzian_derivative,
     calc_peak_to_peak,
+    peak_finder as auto_peak_finder,
 )
 from .io import ESRLoader
 
@@ -305,6 +306,12 @@ class SpanPeakSelector:
         ]
         self.ranges = self.ranges_all[self.current]
 
+        # Automatically detected peak indices per trace
+        self.auto_peaks_all: list[list[tuple[int, int]]] = [
+            [] for _ in self.spectra
+        ]
+        self.auto_peaks = self.auto_peaks_all[self.current]
+
         # GUI related attributes are initialised lazily in ``show`` so that the
         # class can be instantiated in environments without a display (e.g. the
         # test suite).
@@ -314,6 +321,7 @@ class SpanPeakSelector:
         self.lorentz_tree: ttk.Treeview | None = None
         self.analyse_btn: tk.Button | None = None
         self.dhpp_btn: tk.Button | None = None
+        self.find_btn: tk.Button | None = None
         self.fit_btn: tk.Button | None = None
         self.compare_btn: tk.Button | None = None
         self.compare_tree: ttk.Treeview | None = None
@@ -454,10 +462,49 @@ class SpanPeakSelector:
         if peak_choice is None:
             return
         self.current_peak = int(peak_choice)
-
-        self.ranges.clear()
         self.analysis_func = analysis_func
         self.analysis_label = label
+
+        if len(self.auto_peaks) >= self.current_peak:
+            pos_idx, neg_idx = self.auto_peaks[self.current_peak - 1]
+            width = self.analysis_func(
+                self.spectrum.field, self.spectrum.intensity, pos_idx, neg_idx
+            )
+            pos_field = self.spectrum.field[pos_idx]
+            pos_y = self.spectrum.intensity[pos_idx]
+            neg_field = self.spectrum.field[neg_idx]
+            neg_y = self.spectrum.intensity[neg_idx]
+            result = {
+                "analysis": self.analysis_label,
+                "peak": int(self.current_peak),
+                "pos_x": float(pos_field),
+                "pos_y": float(pos_y),
+                "neg_x": float(neg_field),
+                "neg_y": float(neg_y),
+                "width": float(width),
+            }
+            self.results.append(result)
+            if self.tree is not None:
+                self.tree.insert(
+                    "",
+                    tk.END,
+                    values=(
+                        self.analysis_label,
+                        f"{self.current_peak}",
+                        f"{pos_field:.3f}",
+                        f"{pos_y:.3f}",
+                        f"{neg_field:.3f}",
+                        f"{neg_y:.3f}",
+                        f"{width:.3f}",
+                    ),
+                )
+            messagebox.showinfo(
+                "Peak analysis",
+                f"Peak {self.current_peak}: pos={pos_field:.3f}, neg={neg_field:.3f}, {self.analysis_label}={width:.3f}",
+            )
+            return
+
+        self.ranges.clear()
         if self.selector is not None:
             self.selector.disconnect_events()
         assert self.ax is not None
@@ -468,11 +515,65 @@ class SpanPeakSelector:
             self.analyse_btn.config(state=tk.DISABLED)
         if self.dhpp_btn is not None:
             self.dhpp_btn.config(state=tk.DISABLED)
+        if self.find_btn is not None:
+            self.find_btn.config(state=tk.DISABLED)
 
     def start_peak_to_peak(self) -> None:
         """Start interactive \u0394H_pp analysis using span selection."""
 
         self.start_analysis(calc_peak_to_peak, "\u0394H_pp")
+
+    def peak_finder(self) -> None:
+        """Automatically detect peak pairs for the active spectrum."""
+
+        try:
+            num = simpledialog.askinteger(
+                "Peak Finder", "How many peaks to expect?", initialvalue=4, minvalue=2
+            )
+        except Exception:
+            num = 4
+        if num is None:
+            return
+
+        spec = self.spectra[self.current]
+        field = spec.field
+        intensity = spec.intensity
+        try:
+            pairs = auto_peak_finder(field, intensity, expected=int(num))
+        except ValueError as exc:
+            messagebox.showerror("Peak Finder", str(exc))
+            return
+
+        assert self.ax is not None
+        temp_marks = []
+        for p, n in pairs:
+            pos_mark = self.ax.plot(field[p], intensity[p], "o", color="red")[0]
+            neg_mark = self.ax.plot(field[n], intensity[n], "o", color="blue")[0]
+            temp_marks.extend([pos_mark, neg_mark])
+        self.ax.figure.canvas.draw_idle()
+
+        lines = [
+            (
+                f"Peak {i + 1}: pos=({field[p]:.3f}, {intensity[p]:.3f}), "
+                f"neg=({field[n]:.3f}, {intensity[n]:.3f})"
+            )
+            for i, (p, n) in enumerate(pairs)
+        ]
+        accept = messagebox.askyesno(
+            "Peak Finder", "\n".join(lines) + "\nAccept peaks?"
+        )
+
+        for mark in temp_marks:
+            mark.remove()
+        self.ax.figure.canvas.draw_idle()
+
+        if not accept:
+            return
+
+        self.auto_peaks_all[self.current].clear()
+        self.auto_peaks_all[self.current].extend(pairs)
+        self.auto_peaks = self.auto_peaks_all[self.current]
+        messagebox.showinfo("Peak Finder", "Peaks stored for analysis")
 
     # ------------------------------------------------------------------
     def onselect(self, xmin: float, xmax: float) -> None:
@@ -533,6 +634,8 @@ class SpanPeakSelector:
             self.analyse_btn.config(state=tk.NORMAL)
         if self.dhpp_btn is not None:
             self.dhpp_btn.config(state=tk.NORMAL)
+        if self.find_btn is not None:
+            self.find_btn.config(state=tk.NORMAL)
 
         # Maintain backwards-compatible notification for the tests
         messagebox.showinfo("Peak analysis", "\n".join(lines))
@@ -796,6 +899,7 @@ class SpanPeakSelector:
         self.results = self.results_all[self.current]
         self.lorentz_results = self.lorentz_all[self.current]
         self.ranges = self.ranges_all[self.current]
+        self.auto_peaks = self.auto_peaks_all[self.current]
 
         field_min = float(np.min(self.spectrum.field))
         field_max = float(np.max(self.spectrum.field))
@@ -882,6 +986,11 @@ class SpanPeakSelector:
             panel, text="Analyse \u0394H_pp", command=self.start_peak_to_peak
         )
         self.dhpp_btn.pack(padx=5, pady=5)
+
+        self.find_btn = tk.Button(
+            panel, text="Find Peaks", command=self.peak_finder
+        )
+        self.find_btn.pack(padx=5, pady=5)
 
         field_min = float(np.min(self.spectrum.field))
         field_max = float(np.max(self.spectrum.field))

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -6,6 +6,7 @@ from esr_lab import (
     calc_fwhm,
     fit_lorentzian_derivative,
     calc_peak_to_peak,
+    peak_finder,
 )
 
 
@@ -52,3 +53,17 @@ def test_fit_lorentzian_derivative_parameters():
     params = fit_lorentzian_derivative(field, intensity)
 
     assert np.allclose(params, (H_res, delta, A, B), atol=1e-6)
+
+
+def test_peak_finder_pairs():
+    field = np.arange(20.0)
+    intensity = np.array(
+        [
+            0, 1, 0, -1, 0, 2, 0, -2, 0, 0,
+            0, 1.5, 0, -1.5, 0, 0.5, 0, -0.5, 0, 0,
+        ]
+    )
+
+    pairs = peak_finder(field, intensity)
+
+    assert pairs == [(5, 7), (11, 13)]


### PR DESCRIPTION
## Summary
- refine `peak_finder` to choose strongest positive/negative peaks and pair them by field proximity
- restrict GUI peak finder to the selected spectrum and display temporary markers with coordinates before storing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af1592a4508324b3e652a506e83a05