### PR TITLE
Add chi-square metrics and residual plotting for Lorentzian fits

### DIFF
--- a/esr_lab/__init__.py
+++ b/esr_lab/__init__.py
@@ -3,21 +3,25 @@
 from .spectrum import ESRSpectrum
 from .io import ESRLoader
 from .plotter import ESRPlotter
+from .plotter import plot_residuals
 from .analysis import (
     find_peak,
     calc_fwhm,
     fit_lorentzian_derivative,
     calc_peak_to_peak,
     peak_finder,
+    chi_square,
 )
 
 __all__ = [
     "ESRSpectrum",
     "ESRLoader",
     "ESRPlotter",
+    "plot_residuals",
     "find_peak",
     "calc_fwhm",
     "fit_lorentzian_derivative",
     "calc_peak_to_peak",
     "peak_finder",
+    "chi_square",
 ]

--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -211,11 +211,42 @@ def peak_finder(
     return pairs
 
 
+def chi_square(
+    observed: np.ndarray,
+    expected: np.ndarray,
+    dof: int | None = None,
+) -> float:
+    """Calculate the (reduced) chi-square statistic for two data sets.
+
+    Parameters
+    ----------
+    observed:
+        Array of measured values.
+    expected:
+        Array of expected values from a model.
+    dof:
+        Degrees of freedom. If provided, the returned value is the reduced
+        chi-square where ``chi2 / dof`` is computed.  When omitted the raw
+        chi-square sum of squared residuals is returned.
+
+    Returns
+    -------
+    float
+        The chi-square or reduced chi-square statistic.
+    """
+
+    residuals = observed - expected
+    chi2 = float(np.sum(residuals**2))
+    if dof is not None and dof > 0:
+        chi2 /= dof
+    return chi2
+
+
 def fit_lorentzian_derivative(
     field: np.ndarray,
     intensity: np.ndarray,
     p0: tuple[float, float, float, float] | None = None,
-) -> tuple[float, float, float, float]:
+) -> tuple[tuple[float, float, float, float], dict[str, object]]:
     """Fit a derivative ESR line to a Lorentzian derivative model.
 
     The measured ESR signal in derivative mode can be represented as the
@@ -247,6 +278,11 @@ def fit_lorentzian_derivative(
     -------
     tuple[float, float, float, float]
         Fitted parameters ``(H_res, delta, A, B)``.
+    dict[str, object]
+        A dictionary with diagnostic information.  Keys are ``"chi2"`` for the
+        reduced chi-square statistic, ``"stderr"`` containing the standard error
+        of the fitted parameters as a tuple and ``"residuals"`` holding the
+        residual array.
     """
 
     def _model(H: np.ndarray, H_res: float, delta: float, A: float, B: float) -> np.ndarray:
@@ -267,6 +303,17 @@ def fit_lorentzian_derivative(
 
     from scipy.optimize import curve_fit
 
-    popt, _ = curve_fit(_model, field, intensity, p0=p0)
+    popt, pcov = curve_fit(_model, field, intensity, p0=p0)
     h_res, delta, A, B = popt
-    return float(h_res), float(delta), float(A), float(B)
+
+    fitted = _model(field, h_res, delta, A, B)
+    residuals = intensity - fitted
+    chi2 = chi_square(intensity, fitted, dof=len(field) - len(popt))
+    stderr = np.sqrt(np.diag(pcov))
+    stats = {
+        "chi2": float(chi2),
+        "stderr": tuple(float(s) for s in stderr),
+        "residuals": residuals.astype(float),
+    }
+
+    return (float(h_res), float(delta), float(A), float(B)), stats

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -29,6 +29,7 @@ from .analysis import (
     peak_finder as auto_peak_finder,
 )
 from .io import ESRLoader
+from .plotter import plot_residuals
 
 
 def _filter_ticks(ticks: list[float], lower: float, upper: float) -> list[float]:
@@ -734,9 +735,12 @@ class SpanPeakSelector:
                 a_guess = 1.0
 
         p0 = (self.selected_peak, delta_guess, a_guess, 0.0)
-        params = fit_lorentzian_derivative(field, intensity, p0=p0)
+        params, stats = fit_lorentzian_derivative(field, intensity, p0=p0)
 
         h_res, delta, A, B = params
+        chi2 = stats["chi2"]
+        stderr = stats["stderr"]
+        residuals = stats["residuals"]
 
         def _model(H: np.ndarray, H_res: float, delta: float, A: float, B: float):
             x = H - H_res
@@ -750,11 +754,16 @@ class SpanPeakSelector:
         self.ax.legend()
         self.ax.figure.canvas.draw_idle()
 
+        # Show residual plot
+        plot_residuals(field, residuals)
+
         accept = messagebox.askyesno(
             "Lorentzian Fit",
             (
                 f"H_res={h_res:.3f}\n"
-                f"Delta={delta:.3f}\nA={A:.3f}\nB={B:.3f}\nAccept fit?"
+                f"Delta={delta:.3f}\nA={A:.3f}\nB={B:.3f}\n"
+                f"chi^2={chi2:.3e}\n"
+                f"stderr={stderr}\nAccept fit?"
             ),
         )
 

--- a/esr_lab/plotter.py
+++ b/esr_lab/plotter.py
@@ -123,3 +123,27 @@ def configure_subplot(
         if minor_grid:
             ax.minorticks_on()
         ax.grid(minor_grid, which="minor")
+
+
+def plot_residuals(field: Sequence[float], residuals: Sequence[float]) -> None:
+    """Plot residuals of a fit against the magnetic field.
+
+    A simple helper used to visualise the difference between measured data and
+    a fitted model.  The function draws a scatter plot of the residuals and a
+    horizontal line at zero for reference.
+
+    Parameters
+    ----------
+    field:
+        Magnetic-field values of the data points.
+    residuals:
+        Residuals ``observed - fitted`` corresponding to ``field``.
+    """
+
+    fig, ax = plt.subplots()
+    ax.axhline(0.0, color="black", linewidth=0.8)
+    ax.plot(field, residuals, "o")
+    ax.set_xlabel("Magnetic Field")
+    ax.set_ylabel("Residuals")
+    ax.set_title("Fit Residuals")
+    plt.show()

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -7,6 +7,7 @@ from esr_lab import (
     fit_lorentzian_derivative,
     calc_peak_to_peak,
     peak_finder,
+    chi_square,
 )
 
 
@@ -50,9 +51,20 @@ def test_fit_lorentzian_derivative_parameters():
         delta * (delta**2 - x**2) / denom
     )
 
-    params = fit_lorentzian_derivative(field, intensity)
+    params, stats = fit_lorentzian_derivative(field, intensity)
 
     assert np.allclose(params, (H_res, delta, A, B), atol=1e-6)
+    assert stats["chi2"] == pytest.approx(0.0, abs=1e-12)
+    assert np.allclose(stats["stderr"], (0.0, 0.0, 0.0, 0.0), atol=1e-6)
+    assert np.allclose(stats["residuals"], 0.0, atol=1e-12)
+
+
+def test_chi_square_matches_manual_calculation():
+    observed = np.array([1.0, 2.0, 3.0])
+    expected = np.array([1.0, 2.5, 2.5])
+    residuals = observed - expected
+    manual = np.sum(residuals**2)
+    assert chi_square(observed, expected) == pytest.approx(manual)
 
 
 def test_peak_finder_pairs():

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -207,13 +207,15 @@ def test_lorentzian_fit_overlay():
     selector.ax.plot(spectrum.field, spectrum.intensity)
     selector.selected_peak = -0.5
     with patch(
-        "esr_lab.gui.fit_lorentzian_derivative", return_value=(0.0, 1.0, 1.0, 0.0)
+        "esr_lab.gui.fit_lorentzian_derivative",
+        return_value=((0.0, 1.0, 1.0, 0.0), {"chi2": 0.0, "stderr": (0, 0, 0, 0), "residuals": np.zeros(5)}),
     ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=True) as ask, patch(
         "esr_lab.gui.simpledialog.askinteger", return_value=1
-    ):
+    ), patch("esr_lab.gui.plot_residuals") as plot_res:
         selector.fit_lorentzian()
         fit.assert_called_once()
         ask.assert_called_once()
+        plot_res.assert_called_once()
         assert len(selector.ax.lines) == 2
     plt.close(fig)
 
@@ -221,10 +223,11 @@ def test_lorentzian_fit_overlay():
     selector.ax.plot(spectrum.field, spectrum.intensity)
     selector.selected_peak = 0.5
     with patch(
-        "esr_lab.gui.fit_lorentzian_derivative", return_value=(0.0, 1.0, 1.0, 0.0)
+        "esr_lab.gui.fit_lorentzian_derivative",
+        return_value=((0.0, 1.0, 1.0, 0.0), {"chi2": 0.0, "stderr": (0, 0, 0, 0), "residuals": np.zeros(5)}),
     ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=False) as ask, patch(
         "esr_lab.gui.simpledialog.askinteger", return_value=1
-    ):
+    ), patch("esr_lab.gui.plot_residuals"):
         selector.fit_lorentzian()
         fit.assert_called_once()
         ask.assert_called_once()
@@ -241,10 +244,10 @@ def test_lorentzian_fit_results_tabulated():
     selector.lorentz_tree = MagicMock()
     with patch(
         "esr_lab.gui.fit_lorentzian_derivative",
-        return_value=(0.0, 1.0, 2.0, 3.0),
+        return_value=((0.0, 1.0, 2.0, 3.0), {"chi2": 0.0, "stderr": (0, 0, 0, 0), "residuals": np.zeros(5)}),
     ) as fit, patch("esr_lab.gui.messagebox.askyesno", return_value=True), patch(
         "esr_lab.gui.simpledialog.askinteger", return_value=1
-    ):
+    ), patch("esr_lab.gui.plot_residuals"):
         selector.fit_lorentzian()
         fit.assert_called_once()
     assert selector.lorentz_results == [

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -4,7 +4,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from unittest.mock import patch
 
-from esr_lab.plotter import ESRPlotter, configure_subplot
+from esr_lab.plotter import ESRPlotter, configure_subplot, plot_residuals
 from esr_lab.spectrum import ESRSpectrum
 
 
@@ -78,3 +78,12 @@ def test_configure_subplot_allows_customisation():
     assert ax.xaxis._major_tick_kw["gridOn"]
     assert ax.xaxis._minor_tick_kw["gridOn"]
     plt.close(fig)
+
+
+def test_plot_residuals_calls_show():
+    field = np.array([0.0, 1.0])
+    residuals = np.array([0.1, -0.1])
+    with patch("matplotlib.pyplot.show") as show_mock:
+        plot_residuals(field, residuals)
+        show_mock.assert_called_once()
+    plt.close("all")


### PR DESCRIPTION
## Summary
- compute chi-square statistics and parameter standard errors during Lorentzian fitting
- add residual plotting helper and integrate fit diagnostics into GUI
- cover new functionality with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4e8983cc83249387423ffa6922f5