### PR TITLE
Title residual plots with fit peak values

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -757,7 +757,7 @@ class SpanPeakSelector:
         self.ax.figure.canvas.draw_idle()
 
         # Show residual plot
-        res_plot = plot_residuals(field, residuals, show=self.plot_frame is None)
+        res_plot = plot_residuals(field, residuals, h_res, show=self.plot_frame is None)
         if self.plot_frame is not None and isinstance(res_plot, tuple):
             fig_r, _ax_r = res_plot
             canvas_r = FigureCanvasTkAgg(fig_r, master=self.plot_frame)

--- a/esr_lab/plotter.py
+++ b/esr_lab/plotter.py
@@ -128,6 +128,7 @@ def configure_subplot(
 def plot_residuals(
     field: Sequence[float],
     residuals: Sequence[float],
+    peak: float,
     *,
     show: bool = True,
 ):
@@ -143,6 +144,8 @@ def plot_residuals(
         Magnetic-field values of the data points.
     residuals:
         Residuals ``observed - fitted`` corresponding to ``field``.
+    peak:
+        Resonance field for which the fit was performed.
     """
 
     fig, ax = plt.subplots()
@@ -150,7 +153,7 @@ def plot_residuals(
     ax.plot(field, residuals, "o")
     ax.set_xlabel("Magnetic Field")
     ax.set_ylabel("Residuals")
-    ax.set_title("Fit Residuals")
+    ax.set_title(f"Residual fit peak {peak}")
     if show:
         plt.show()
     return fig, ax

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -84,7 +84,7 @@ def test_plot_residuals_calls_show():
     field = np.array([0.0, 1.0])
     residuals = np.array([0.1, -0.1])
     with patch("matplotlib.pyplot.show") as show_mock:
-        plot_residuals(field, residuals)
+        plot_residuals(field, residuals, peak=1)
         show_mock.assert_called_once()
     plt.close("all")
 
@@ -93,7 +93,8 @@ def test_plot_residuals_returns_figure_without_show():
     field = np.array([0.0, 1.0])
     residuals = np.array([0.1, -0.1])
     with patch("matplotlib.pyplot.show") as show_mock:
-        fig, ax = plot_residuals(field, residuals, show=False)
+        fig, ax = plot_residuals(field, residuals, peak=1, show=False)
         show_mock.assert_not_called()
         assert ax.get_ylabel() == "Residuals"
+        assert ax.get_title() == "Residual fit peak 1"
     plt.close(fig)


### PR DESCRIPTION
## Summary
- Display peak-specific titles on residual plots
- Pass fitted resonance field to residual plot helper
- Test residual plotting with peak-aware titles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af57b54c94832499df58944d4becce