### PR TITLE
feat: add help menu with documentation

### DIFF
--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -317,3 +317,30 @@ def fit_lorentzian_derivative(
     }
 
     return (float(h_res), float(delta), float(A), float(B)), stats
+
+
+# ---------------------------------------------------------------------------
+# Metadata for help menu
+# ---------------------------------------------------------------------------
+FUNCTION_DETAILS: dict[str, tuple[str, str]] = {
+    "find_peak": (
+        "Locate the positive and negative peaks within a field window",
+        "",
+    ),
+    "calc_fwhm": (
+        "Estimate the full width at half maximum (FWHM)",
+        "FWHM = |H_+ - H_-|",
+    ),
+    "calc_peak_to_peak": (
+        "Compute the peak-to-peak separation \u0394H_pp",
+        "\u0394H_pp = |H_+ - H_-|",
+    ),
+    "peak_finder": (
+        "Automatically locate peak pairs in the provided data",
+        "",
+    ),
+    "fit_lorentzian_derivative": (
+        "Fit a derivative ESR line to a Lorentzian derivative model",
+        "dI/dH = A\u00b7\u2202_H L_abs(H) + B\u00b7\u2202_H L_disp(H)",
+    ),
+}

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -27,6 +27,7 @@ from .analysis import (
     fit_lorentzian_derivative,
     calc_peak_to_peak,
     peak_finder as auto_peak_finder,
+    FUNCTION_DETAILS,
 )
 from .io import ESRLoader
 from .plotter import plot_residuals
@@ -1065,11 +1066,64 @@ class SpanPeakSelector:
         self.ax.figure.canvas.draw_idle()
 
     # ------------------------------------------------------------------
+    def _show_readme(self) -> None:
+        """Display the project README in a message box."""
+        try:
+            readme_path = Path(__file__).resolve().parent.parent / "README.md"
+            text = readme_path.read_text(encoding="utf-8")
+        except Exception as exc:
+            text = f"Unable to load README: {exc}"
+        messagebox.showinfo("README", text)
+
+    # ------------------------------------------------------------------
+    def _show_workflow(self) -> None:
+        """Show a brief description of the typical workflow."""
+        workflow = (
+            "1. Load one or more CSV files containing ESR spectra.\n"
+            "2. Use the controls to select peaks and perform analyses.\n"
+            "3. Review the results in the tables on the right.\n"
+            "4. Optionally fit Lorentzian lines or compare spectra."
+        )
+        messagebox.showinfo("Workflow", workflow)
+
+    # ------------------------------------------------------------------
+    def _show_functions(self) -> None:
+        """List available analysis functions with short descriptions."""
+        lines: list[str] = []
+        for name, (desc, formula) in FUNCTION_DETAILS.items():
+            lines.append(f"{name}: {desc}")
+            if formula:
+                lines.append(f"    {formula}")
+            lines.append("")
+        messagebox.showinfo("Functions", "\n".join(lines))
+
+    # ------------------------------------------------------------------
+    def _create_menu(self) -> None:
+        """Create the menu bar with a Help menu."""
+        if self.root is None:
+            return
+        try:
+            menubar = tk.Menu(self.root)
+            help_menu = tk.Menu(menubar, tearoff=0)
+            help_menu.add_command(label="Readme", command=self._show_readme)
+            help_menu.add_command(label="Workflow", command=self._show_workflow)
+            help_menu.add_command(label="Functions", command=self._show_functions)
+            menubar.add_cascade(label="Help", menu=help_menu)
+            self.root.config(menu=menubar)
+        except Exception:
+            # In headless environments or tests the Tk primitives may not be
+            # fully initialised.  Failing silently keeps the rest of the GUI
+            # functional while still allowing the menu to appear when running
+            # interactively.
+            pass
+
+    # ------------------------------------------------------------------
     def show(self) -> None:
         """Start the Tkinter main loop and display the analysis GUI."""
 
         self.root = tk.Tk()
         self.root.title("ESR Spectrum")
+        self._create_menu()
 
         ButtonCls: type[tk.Button] | type[ttk.Button] = ttk.Button
         button_kwargs: dict[str, object] = {"style": "Compact.TButton"}

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -419,3 +419,67 @@ def test_trace_visibility_toggle_updates_legend():
     assert len(selector.ax.get_legend().get_texts()) == 2
     plt.close(fig)
 
+
+def test_help_menu_created(monkeypatch):
+    spectrum = ESRSpectrum(field=np.arange(5.0), intensity=np.zeros(5))
+    selector = gui.SpanPeakSelector(spectrum)
+
+    class DummyRoot:
+        def __init__(self):
+            self.menu = None
+
+        def config(self, **kwargs):
+            self.menu = kwargs.get("menu")
+
+    root = DummyRoot()
+    selector.root = root
+
+    class DummyMenu:
+        def __init__(self, master=None, tearoff=0):
+            self.items = []
+            self.cascade = None
+
+        def add_command(self, label, command):
+            self.items.append(("command", label, command))
+
+        def add_cascade(self, label, menu):
+            self.cascade = (label, menu)
+
+    monkeypatch.setattr(gui.tk, "Menu", DummyMenu)
+
+    selector._create_menu()
+
+    assert isinstance(root.menu, DummyMenu)
+    assert root.menu.cascade[0] == "Help"
+    help_menu = root.menu.cascade[1]
+    expected = [
+        ("command", "Readme", selector._show_readme),
+        ("command", "Workflow", selector._show_workflow),
+        ("command", "Functions", selector._show_functions),
+    ]
+    assert help_menu.items == expected
+
+
+def test_help_dialogs(monkeypatch):
+    spectrum = ESRSpectrum(field=np.arange(5.0), intensity=np.zeros(5))
+    selector = gui.SpanPeakSelector(spectrum)
+
+    info = MagicMock()
+    monkeypatch.setattr(gui.messagebox, "showinfo", info)
+
+    monkeypatch.setattr(gui.Path, "read_text", lambda self, encoding="utf-8": "readme text")
+    selector._show_readme()
+    info.assert_called_with("README", "readme text")
+
+    info.reset_mock()
+    selector._show_workflow()
+    assert info.call_args[0][0] == "Workflow"
+
+    info.reset_mock()
+    monkeypatch.setattr(gui, "FUNCTION_DETAILS", {"f": ("desc", "math")})
+    selector._show_functions()
+    call = info.call_args
+    assert call[0][0] == "Functions"
+    assert "desc" in call[0][1]
+    assert "math" in call[0][1]
+


### PR DESCRIPTION
## Summary
- add help menu to GUI with README, workflow overview, and function reference
- provide function metadata and formulas for help dialog
- test new help menu and dialogs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af5871bec48324bb693ebbff8a5b5f