### PR TITLE
Improve functions help display with LaTeX-style formatting

### DIFF
--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -329,11 +329,11 @@ FUNCTION_DETAILS: dict[str, tuple[str, str]] = {
     ),
     "calc_fwhm": (
         "Estimate the full width at half maximum (FWHM)",
-        "FWHM = |H_+ - H_-|",
+        r"$\mathrm{FWHM} = |H_{+} - H_{-}|$",
     ),
     "calc_peak_to_peak": (
-        "Compute the peak-to-peak separation \u0394H_pp",
-        "\u0394H_pp = |H_+ - H_-|",
+        r"Compute the peak-to-peak separation $\Delta H_{pp}$",
+        r"$\Delta H_{pp} = |H_{+} - H_{-}|$",
     ),
     "peak_finder": (
         "Automatically locate peak pairs in the provided data",
@@ -341,6 +341,6 @@ FUNCTION_DETAILS: dict[str, tuple[str, str]] = {
     ),
     "fit_lorentzian_derivative": (
         "Fit a derivative ESR line to a Lorentzian derivative model",
-        "dI/dH = A\u00b7\u2202_H L_abs(H) + B\u00b7\u2202_H L_disp(H)",
+        r"$\frac{dI}{dH} = A\partial_H L_{\text{abs}}(H) + B\partial_H L_{\text{disp}}(H)$",
     ),
 }

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -1091,11 +1091,12 @@ class SpanPeakSelector:
         """List available analysis functions with short descriptions."""
         lines: list[str] = []
         for name, (desc, formula) in FUNCTION_DETAILS.items():
-            lines.append(f"{name}: {desc}")
+            lines.append(name)
+            lines.append(f"    {desc}")
             if formula:
                 lines.append(f"    {formula}")
             lines.append("")
-        messagebox.showinfo("Functions", "\n".join(lines))
+        messagebox.showinfo("Functions", "\n".join(lines).rstrip())
 
     # ------------------------------------------------------------------
     def _create_menu(self) -> None:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -476,10 +476,12 @@ def test_help_dialogs(monkeypatch):
     assert info.call_args[0][0] == "Workflow"
 
     info.reset_mock()
-    monkeypatch.setattr(gui, "FUNCTION_DETAILS", {"f": ("desc", "math")})
+    monkeypatch.setattr(gui, "FUNCTION_DETAILS", {"f": ("desc", r"$x^2$")})
     selector._show_functions()
     call = info.call_args
     assert call[0][0] == "Functions"
-    assert "desc" in call[0][1]
-    assert "math" in call[0][1]
+    lines = call[0][1].splitlines()
+    assert lines[0] == "f"
+    assert lines[1].strip() == "desc"
+    assert lines[2].strip() == r"$x^2$"
 


### PR DESCRIPTION
## Summary
- Format analysis function metadata using LaTeX-style expressions
- Display function help with separate name, description and formula lines
- Test help dialog for LaTeX-like formatting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5a78d6cc8324bf269dadab3fede8