### PR TITLE
Add baseline correction with manual and auto options

### DIFF
--- a/esr_lab/__init__.py
+++ b/esr_lab/__init__.py
@@ -11,6 +11,7 @@ from .analysis import (
     calc_peak_to_peak,
     peak_finder,
     chi_square,
+    baseline_correct,
 )
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "calc_peak_to_peak",
     "peak_finder",
     "chi_square",
+    "baseline_correct",
 ]

--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -211,6 +211,48 @@ def peak_finder(
     return pairs
 
 
+def baseline_correct(
+    field: np.ndarray,
+    intensity: np.ndarray,
+    points: list[tuple[float, float]] | None = None,
+    degree: int = 1,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Perform a simple polynomial baseline correction.
+
+    Parameters
+    ----------
+    field:
+        Array of magnetic-field values.
+    intensity:
+        Recorded intensity values corresponding to ``field``.
+    points:
+        Optional list of ``(x, y)`` coordinates defining the baseline.  When
+        provided a polynomial is fitted through these points.  Otherwise a
+        polynomial of ``degree`` is fitted to the entire trace.
+    degree:
+        Degree of the polynomial used for automatic baseline fitting.  The
+        default of ``1`` corresponds to a linear baseline.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        The baseline corrected intensity and the fitted baseline evaluated over
+        ``field``.
+    """
+
+    if points:
+        xp = np.array([p[0] for p in points], dtype=float)
+        yp = np.array([p[1] for p in points], dtype=float)
+        deg = min(len(xp) - 1, 3)
+        coeffs = np.polyfit(xp, yp, deg)
+    else:
+        coeffs = np.polyfit(field, intensity, degree)
+
+    baseline = np.polyval(coeffs, field)
+    corrected = intensity - baseline
+    return corrected.astype(float), baseline.astype(float)
+
+
 def chi_square(
     observed: np.ndarray,
     expected: np.ndarray,
@@ -337,6 +379,10 @@ FUNCTION_DETAILS: dict[str, tuple[str, str]] = {
     ),
     "peak_finder": (
         "Automatically locate peak pairs in the provided data",
+        "",
+    ),
+    "baseline_correct": (
+        "Perform a polynomial baseline correction",
         "",
     ),
     "fit_lorentzian_derivative": (

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 import numpy as np
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
-from matplotlib.widgets import SpanSelector
+from matplotlib.widgets import SpanSelector, Cursor
 from typing import Callable
 from scipy.integrate import cumulative_trapezoid
 
@@ -27,6 +27,7 @@ from .analysis import (
     fit_lorentzian_derivative,
     calc_peak_to_peak,
     peak_finder as auto_peak_finder,
+    baseline_correct,
     FUNCTION_DETAILS,
 )
 from .io import ESRLoader
@@ -356,6 +357,7 @@ class SpanPeakSelector:
         self.find_btn: tk.Button | ttk.Button | None = None
         self.fit_btn: tk.Button | ttk.Button | None = None
         self.integrate_btn: tk.Button | ttk.Button | None = None
+        self.baseline_btn: tk.Button | ttk.Button | None = None
         self.compare_btn: tk.Button | ttk.Button | None = None
         self.compare_tree: ttk.Treeview | None = None
         self.trace_combo: ttk.Combobox | None = None
@@ -871,6 +873,49 @@ class SpanPeakSelector:
             )
 
     # ------------------------------------------------------------------
+    def baseline_correction(self) -> None:
+        """Apply a baseline correction to the currently selected trace."""
+
+        if self.ax is None:
+            return
+
+        use_auto = messagebox.askyesno(
+            "Baseline Correction",
+            "Use automatic baseline fit?\nSelect 'No' for manual placement.",
+        )
+
+        field = self.spectrum.field
+        intensity = self.spectrum.intensity
+
+        if use_auto:
+            corrected, _baseline = baseline_correct(field, intensity)
+        else:
+            fig = self.ax.figure
+            plt.figure(fig.number)
+            cursor = Cursor(self.ax, useblit=True, color="red", linewidth=1)
+            try:
+                pts = plt.ginput(n=-1, timeout=-1)
+            except Exception:
+                pts = []
+            finally:
+                try:
+                    cursor.disconnect_events()
+                except Exception:
+                    pass
+            if len(pts) < 2:
+                messagebox.showwarning(
+                    "Baseline Correction",
+                    "At least two points are required for manual baseline correction.",
+                )
+                return
+            corrected, _baseline = baseline_correct(field, intensity, points=pts)
+
+        self.spectrum.intensity = corrected
+        line = self.trace_lines[self.current]
+        line.set_ydata(corrected)
+        self.ax.figure.canvas.draw_idle()
+
+    # ------------------------------------------------------------------
     def integrate_trace(self) -> None:
         """Integrate the selected derivative trace and plot the absorption spectrum."""
 
@@ -1339,6 +1384,14 @@ class SpanPeakSelector:
             **button_kwargs,
         )
         self.integrate_btn.pack(side=tk.LEFT, padx=2, pady=2)
+
+        self.baseline_btn = ButtonCls(
+            button_row2,
+            text="Baseline Correct",
+            command=self.baseline_correction,
+            **button_kwargs,
+        )
+        self.baseline_btn.pack(side=tk.LEFT, padx=2, pady=2)
 
         self.compare_btn = ButtonCls(
             button_row2,

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -8,6 +8,7 @@ from esr_lab import (
     calc_peak_to_peak,
     peak_finder,
     chi_square,
+    baseline_correct,
 )
 
 
@@ -79,3 +80,19 @@ def test_peak_finder_pairs():
     pairs = peak_finder(field, intensity)
 
     assert pairs == [(5, 7), (11, 13)]
+
+
+def test_baseline_correct_manual_and_auto():
+    field = np.linspace(0, 10, 11)
+    baseline = 0.5 * field + 1.0
+    signal = np.zeros_like(field)
+    intensity = baseline + signal
+
+    corrected, fitted = baseline_correct(
+        field, intensity, points=[(0.0, baseline[0]), (10.0, baseline[-1])]
+    )
+    assert np.allclose(corrected, signal)
+    assert np.allclose(fitted, baseline)
+
+    corrected_auto, _ = baseline_correct(field, intensity)
+    assert np.allclose(corrected_auto, signal)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -200,6 +200,27 @@ def test_multi_trace_results_isolated():
     plt.close(fig)
 
 
+def test_baseline_correction_manual():
+    spectrum = ESRSpectrum(field=np.linspace(0, 1, 3), intensity=np.ones(3))
+    selector = gui.SpanPeakSelector(spectrum)
+    fig, selector.ax = plt.subplots()
+    line = MagicMock()
+    selector.trace_lines = [line]
+    selector.ax.figure.canvas.draw_idle = MagicMock()
+
+    corrected = np.zeros(3)
+    with patch("esr_lab.gui.messagebox.askyesno", return_value=False), \
+        patch("esr_lab.gui.Cursor"), \
+        patch("esr_lab.gui.plt.ginput", return_value=[(0.0, 1.0), (1.0, 1.0)]), \
+        patch("esr_lab.gui.baseline_correct", return_value=(corrected, corrected)) as bc:
+        selector.baseline_correction()
+        bc.assert_called_once()
+        line.set_ydata.assert_called_once_with(corrected)
+        assert np.allclose(selector.spectrum.intensity, corrected)
+
+    plt.close(fig)
+
+
 def test_lorentzian_fit_overlay():
     spectrum = ESRSpectrum(field=np.linspace(-1, 1, 5), intensity=np.zeros(5))
     selector = gui.SpanPeakSelector(spectrum)


### PR DESCRIPTION
## Summary
- Introduce `baseline_correct` for polynomial baseline removal from ESR data
- Expose baseline correction in package API and integrate into GUI
- Provide manual point selection with crosshair and automatic baseline fitting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5c0b07588324ae8eef68b07066de