### PR TITLE
Enhance help menu with SymPy-rendered equations

### DIFF
--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 from scipy.signal import find_peaks
+import sympy as sp
 
 
 def find_peak(
@@ -364,29 +365,39 @@ def fit_lorentzian_derivative(
 # ---------------------------------------------------------------------------
 # Metadata for help menu
 # ---------------------------------------------------------------------------
-FUNCTION_DETAILS: dict[str, tuple[str, str]] = {
+H_plus, H_minus = sp.symbols('H_+ H_-')
+FWHM, ΔH_pp, H = sp.symbols('FWHM ΔH_pp H')
+A, B = sp.symbols('A B')
+I = sp.Function('I')
+L_abs = sp.Function('L_abs')
+L_disp = sp.Function('L_disp')
+
+FUNCTION_DETAILS: dict[str, tuple[str, sp.Expr | None]] = {
     "find_peak": (
         "Locate the positive and negative peaks within a field window",
-        "",
+        None,
     ),
     "calc_fwhm": (
         "Estimate the full width at half maximum (FWHM)",
-        r"$\mathrm{FWHM} = |H_{+} - H_{-}|$",
+        sp.Eq(FWHM, sp.Abs(H_plus - H_minus)),
     ),
     "calc_peak_to_peak": (
-        r"Compute the peak-to-peak separation $\Delta H_{pp}$",
-        r"$\Delta H_{pp} = |H_{+} - H_{-}|$",
+        "Compute the peak-to-peak separation ΔH_pp",
+        sp.Eq(ΔH_pp, sp.Abs(H_plus - H_minus)),
     ),
     "peak_finder": (
         "Automatically locate peak pairs in the provided data",
-        "",
+        None,
     ),
     "baseline_correct": (
         "Perform a polynomial baseline correction",
-        "",
+        None,
     ),
     "fit_lorentzian_derivative": (
         "Fit a derivative ESR line to a Lorentzian derivative model",
-        r"$\frac{dI}{dH} = A\partial_H L_{\text{abs}}(H) + B\partial_H L_{\text{disp}}(H)$",
+        sp.Eq(
+            sp.diff(I(H), H),
+            A * sp.diff(L_abs(H), H) + B * sp.diff(L_disp(H), H),
+        ),
     ),
 }

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -20,6 +20,7 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolb
 from matplotlib.widgets import SpanSelector, Cursor
 from typing import Callable
 from scipy.integrate import cumulative_trapezoid
+import sympy as sp
 
 from .analysis import (
     calc_fwhm,
@@ -1138,8 +1139,13 @@ class SpanPeakSelector:
         for name, (desc, formula) in FUNCTION_DETAILS.items():
             lines.append(name)
             lines.append(f"    {desc}")
-            if formula:
-                lines.append(f"    {formula}")
+            if formula is not None:
+                if isinstance(formula, sp.Basic):
+                    pretty_lines = sp.pretty(formula, use_unicode=True).splitlines()
+                else:
+                    pretty_lines = str(formula).splitlines()
+                for fl in pretty_lines:
+                    lines.append(f"    {fl}")
             lines.append("")
         messagebox.showinfo("Functions", "\n".join(lines).rstrip())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.24
 pandas>=2.0
 matplotlib>=3.7
 scipy>=1.10
+sympy>=1.12

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -3,6 +3,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from unittest.mock import patch, MagicMock
+import sympy as sp
 
 from esr_lab import gui
 from esr_lab.spectrum import ESRSpectrum
@@ -497,12 +498,14 @@ def test_help_dialogs(monkeypatch):
     assert info.call_args[0][0] == "Workflow"
 
     info.reset_mock()
-    monkeypatch.setattr(gui, "FUNCTION_DETAILS", {"f": ("desc", r"$x^2$")})
+    monkeypatch.setattr(gui, "FUNCTION_DETAILS", {"f": ("desc", sp.Symbol("x") ** 2)})
     selector._show_functions()
     call = info.call_args
     assert call[0][0] == "Functions"
     lines = call[0][1].splitlines()
     assert lines[0] == "f"
     assert lines[1].strip() == "desc"
-    assert lines[2].strip() == r"$x^2$"
+    expected = sp.pretty(sp.Symbol("x") ** 2, use_unicode=True).splitlines()
+    for idx, part in enumerate(expected, start=2):
+        assert lines[idx].strip() == part.strip()
 


### PR DESCRIPTION
## Summary
- Display analysis equations using SymPy pretty printing in the GUI help menu
- Store function metadata as SymPy expressions and depend on `sympy`
- Extend tests to cover SymPy formatted equations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5ef751508324b15a4e442ef869b1