### PR TITLE
Refine manual baseline point selection

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -919,10 +919,8 @@ class SpanPeakSelector:
                         "At least two points are required for manual baseline correction.",
                     )
                     return
-                for x, y in raw:
-                    idx = int(
-                        np.argmin((field - x) ** 2 + (intensity - y) ** 2)
-                    )
+                for x, _y in raw:
+                    idx = int(np.argmin((field - x) ** 2))
                     pts.append((float(field[idx]), float(intensity[idx])))
             else:
                 count_var = tk.StringVar(value="Selected points: 0")
@@ -942,12 +940,7 @@ class SpanPeakSelector:
                 def onclick(event):
                     if event.inaxes != self.ax:
                         return
-                    idx = int(
-                        np.argmin(
-                            (field - event.xdata) ** 2
-                            + (intensity - event.ydata) ** 2
-                        )
-                    )
+                    idx = int(np.argmin((field - event.xdata) ** 2))
                     x = float(field[idx])
                     y = float(intensity[idx])
                     pts.append((x, y))

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -202,7 +202,9 @@ def test_multi_trace_results_isolated():
 
 
 def test_baseline_correction_manual():
-    spectrum = ESRSpectrum(field=np.linspace(0, 1, 3), intensity=np.ones(3))
+    spectrum = ESRSpectrum(
+        field=np.array([0.0, 1.0, 2.0]), intensity=np.array([0.0, 100.0, 0.0])
+    )
     selector = gui.SpanPeakSelector(spectrum)
     fig, selector.ax = plt.subplots()
     (line,) = selector.ax.plot(spectrum.field, spectrum.intensity)
@@ -213,12 +215,15 @@ def test_baseline_correction_manual():
     with patch(
         "esr_lab.gui.messagebox.askyesno", side_effect=[True, False]
     ), patch(
-        "esr_lab.gui.plt.ginput", return_value=[(0.0, 1.0), (1.0, 1.0)]
+        "esr_lab.gui.plt.ginput",
+        return_value=[(1.9, 100.0), (0.1, -50.0)],
     ), patch(
         "esr_lab.gui.baseline_correct", return_value=(corrected, corrected)
     ) as bc:
         selector.baseline_correction()
         bc.assert_called_once()
+        # ensure closest x-coordinate is used regardless of y
+        assert bc.call_args.kwargs["points"] == [(2.0, 0.0), (0.0, 0.0)]
         assert len(selector.spectra) == 2
         assert np.allclose(selector.spectra[-1].intensity, corrected)
         assert len(selector.trace_lines) == 2


### PR DESCRIPTION
## Summary
- Select baseline points based only on x-position when manually picking points
- Add regression test ensuring baseline point placement matches x value regardless of y

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af652f515083248cc75cbf5c99f69b