### PR TITLE
feat: autoscale visible traces

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -1138,8 +1138,8 @@ class SpanPeakSelector:
                 chk.pack(anchor="w")
                 self.trace_vars.append(var)
 
-        self.ax.legend()
-        self.ax.figure.canvas.draw_idle()
+        self.update_legend()
+        self._rescale()
 
     # ------------------------------------------------------------------
     def integrate_trace(self) -> None:
@@ -1200,7 +1200,7 @@ class SpanPeakSelector:
                 var.set(True)
 
         self.update_legend()
-        self.ax.figure.canvas.draw_idle()
+        self._rescale()
 
     # ------------------------------------------------------------------
     def save_results(self, path: Path) -> None:
@@ -1301,6 +1301,14 @@ class SpanPeakSelector:
         if self.meta_label is not None:
             self.meta_label.config(text=text)
 
+    def _rescale(self) -> None:
+        """Rescale axes to ensure all visible traces are fully shown."""
+        if self.ax is None:
+            return
+        self.ax.relim(visible_only=True)
+        self.ax.autoscale()
+        self.ax.figure.canvas.draw_idle()
+
     def _on_trace_change(self, _event: object | None = None) -> None:
         """Update state when the user selects a different trace."""
 
@@ -1328,6 +1336,7 @@ class SpanPeakSelector:
 
         self._refresh_tables()
         self._update_metadata_display()
+        self._rescale()
 
     # ------------------------------------------------------------------
     def _toggle_trace(self, index: int, show: bool) -> None:
@@ -1339,8 +1348,7 @@ class SpanPeakSelector:
         self.trace_lines[index].set_visible(show)
 
         self.update_legend()
-        if self.ax is not None:
-            self.ax.figure.canvas.draw_idle()
+        self._rescale()
 
     def _toggle_absorption(self, index: int, show: bool) -> None:
         """Show or hide the integrated absorption trace for the given index."""
@@ -1354,8 +1362,7 @@ class SpanPeakSelector:
 
         line.set_visible(show)
         self.update_legend()
-        if self.ax is not None:
-            self.ax.figure.canvas.draw_idle()
+        self._rescale()
 
     def _set_label(self, index: int, text: str) -> None:
         """Update the stored label for a trace."""

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -660,3 +660,26 @@ def test_help_dialogs(monkeypatch):
     for idx, part in enumerate(expected, start=2):
         assert lines[idx].strip() == part.strip()
 
+
+def test_axes_rescale_on_trace_change_and_toggle():
+    spec1 = ESRSpectrum(field=np.arange(2.0), intensity=np.array([0.0, 1.0]))
+    spec2 = ESRSpectrum(field=np.arange(2.0), intensity=np.array([0.0, 5.0]))
+    selector = gui.SpanPeakSelector([spec1, spec2])
+    fig, selector.ax = plt.subplots()
+    line1, = selector.ax.plot(spec1.field, spec1.intensity)
+    line2, = selector.ax.plot(spec2.field, spec2.intensity)
+    selector.trace_lines = [line1, line2]
+
+    trace_var = MagicMock()
+    trace_var.get.return_value = selector.labels[1]
+    selector.trace_var = trace_var
+
+    selector.ax.set_ylim(-1, 1)
+    selector._on_trace_change()
+    assert selector.ax.get_ylim()[1] > 4.0
+
+    selector._toggle_trace(1, False)
+    assert selector.ax.get_ylim()[1] <= 1.5
+
+    plt.close(fig)
+


### PR DESCRIPTION
## Summary
- ensure axes rescale to show largest visible spectrum when switching or toggling traces
- add regression test for autoscaling behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7a7b3ae08324b243716f94924ee6