### PR TITLE
Add baseline fit selection and auto-fit confirmation

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -301,13 +301,24 @@ class BaselineOptionsDialog(tk.Toplevel):
         self.title("Baseline Options")
         self.resizable(False, False)
 
-        self.use_poly = tk.BooleanVar(value=True)
+        self.fit_type = tk.IntVar(value=1)
         self.use_auto = tk.BooleanVar(value=True)
-        tk.Checkbutton(
+
+        tk.Label(self, text="Baseline fit type:").pack(
+            anchor="w", padx=10, pady=(5, 0)
+        )
+        tk.Radiobutton(
             self,
-            text="Use polynomial baseline",
-            variable=self.use_poly,
-        ).pack(anchor="w", padx=10, pady=5)
+            text="Polynomial fit",
+            variable=self.fit_type,
+            value=1,
+        ).pack(anchor="w", padx=20)
+        tk.Radiobutton(
+            self,
+            text="Linear fit",
+            variable=self.fit_type,
+            value=0,
+        ).pack(anchor="w", padx=20, pady=(0, 5))
         tk.Checkbutton(
             self,
             text="Automatic point placement",
@@ -325,7 +336,7 @@ class BaselineOptionsDialog(tk.Toplevel):
         self.grab_set()
 
     def _on_ok(self) -> None:
-        self.result = (self.use_poly.get(), self.use_auto.get())
+        self.result = (bool(self.fit_type.get()), self.use_auto.get())
         self.destroy()
 
     def _on_cancel(self) -> None:
@@ -1164,6 +1175,17 @@ class SpanPeakSelector:
             corrected, _baseline = baseline_correct(
                 field, intensity, points=pts, degree=degree
             )
+            (preview_line,) = self.ax.plot(
+                field, _baseline, "k--", linewidth=1
+            )
+            self.ax.figure.canvas.draw_idle()
+            confirm = messagebox.askyesno(
+                "Baseline Correction", "Use this automatically generated fit?"
+            )
+            preview_line.remove()
+            self.ax.figure.canvas.draw_idle()
+            if not confirm:
+                return
         else:
             pts: list[tuple[float, float]] = []
             if self.root is None:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -232,6 +232,65 @@ def test_baseline_correction_manual():
     plt.close(fig)
 
 
+def test_baseline_correction_auto_confirm():
+    spectrum = ESRSpectrum(
+        field=np.array([0.0, 1.0, 2.0]), intensity=np.array([1.0, 2.0, 3.0])
+    )
+    selector = gui.SpanPeakSelector(spectrum)
+    fig, selector.ax = plt.subplots()
+    (line,) = selector.ax.plot(spectrum.field, spectrum.intensity)
+    selector.trace_lines = [line]
+    selector.ax.figure.canvas.draw_idle = MagicMock()
+
+    corrected = np.zeros(3)
+    baseline = np.ones(3)
+    with patch(
+        "esr_lab.gui.SpanPeakSelector._get_baseline_options",
+        return_value=(True, True),
+    ), patch(
+        "esr_lab.gui.baseline_correct", return_value=(corrected, baseline)
+    ) as bc, patch(
+        "esr_lab.gui.messagebox.askyesno", return_value=True
+    ) as ask:
+        selector.baseline_correction()
+        bc.assert_called_once()
+        ask.assert_called_once()
+        assert len(selector.spectra) == 2
+        assert np.allclose(selector.spectra[-1].intensity, corrected)
+        assert len(selector.ax.lines) == 2
+
+    plt.close(fig)
+
+
+def test_baseline_correction_auto_cancel():
+    spectrum = ESRSpectrum(
+        field=np.array([0.0, 1.0, 2.0]), intensity=np.array([1.0, 2.0, 3.0])
+    )
+    selector = gui.SpanPeakSelector(spectrum)
+    fig, selector.ax = plt.subplots()
+    (line,) = selector.ax.plot(spectrum.field, spectrum.intensity)
+    selector.trace_lines = [line]
+    selector.ax.figure.canvas.draw_idle = MagicMock()
+
+    corrected = np.zeros(3)
+    baseline = np.ones(3)
+    with patch(
+        "esr_lab.gui.SpanPeakSelector._get_baseline_options",
+        return_value=(False, True),
+    ), patch(
+        "esr_lab.gui.baseline_correct", return_value=(corrected, baseline)
+    ) as bc, patch(
+        "esr_lab.gui.messagebox.askyesno", return_value=False
+    ) as ask:
+        selector.baseline_correction()
+        bc.assert_called_once()
+        ask.assert_called_once()
+        assert len(selector.spectra) == 1
+        assert len(selector.ax.lines) == 1
+
+    plt.close(fig)
+
+
 def test_baseline_editor_clear():
     field = np.linspace(0.0, 2.0, 3)
     intensity = np.zeros(3)


### PR DESCRIPTION
## Summary
- Offer explicit polynomial vs linear fit radio buttons in baseline options dialog
- Preview auto-generated baseline and ask user to confirm before applying
- Test automatic baseline workflow for both confirmation and cancellation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0643f91a8832483d9401d370cba78