### PR TITLE
Switch peak finder to curvature for absorption traces

### DIFF
--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -125,13 +125,20 @@ def peak_finder(
     intensity: np.ndarray,
     expected: int = 4,
     width: float = 15.0,
+    method: str = "zero",
 ) -> list[tuple[int, int]]:
     """Automatically locate peak pairs in the provided data.
 
-    This implementation relies on the derivative spectrum crossing zero between
-    the positive and negative extrema of an absorption peak.  Around each zero
-    crossing, local extrema are searched within a window of ``±width`` and
-    paired up to yield the peak positions.
+    Two approaches are supported:
+
+    ``method="zero"`` (default)
+        Operates on derivative-mode data by locating zero crossings and
+        searching for extrema in a window of ``±width`` around each crossing.
+
+    ``method="curvature"``
+        Intended for absorption spectra.  It evaluates the curvature of the
+        trace via the first derivative and pairs up maxima and minima of this
+        derivative.  The ``width`` parameter is ignored in this mode.
 
     Parameters
     ----------
@@ -146,7 +153,12 @@ def peak_finder(
     width:
         Half width in magnetic-field units used around each zero crossing to
         determine the local maxima and minima.  The default of ``15.0`` mT
-        mirrors the manual analysis range used in the GUI.
+        mirrors the manual analysis range used in the GUI.  Ignored when
+        ``method="curvature"``.
+    method:
+        ``"zero"`` to base the detection on zero crossings of the provided
+        trace (appropriate for derivative spectra) or ``"curvature"`` to analyse
+        the curvature of an absorption trace.
 
     Returns
     -------
@@ -164,47 +176,85 @@ def peak_finder(
     if expected < 2 or expected % 2 != 0:
         raise ValueError("Expected number of peaks must be an even integer >= 2")
 
-    # Identify zero crossings where the signal changes from positive to
-    # negative.  Zeros are ignored by using ``nan`` and compressing the array to
-    # regions of constant sign.
-    sign = np.sign(intensity)
-    sign = np.where(sign == 0, np.nan, sign)
-    nonzero_idx = np.where(~np.isnan(sign))[0]
-    if nonzero_idx.size == 0:
-        raise ValueError("No non-zero data points found")
-    nonzero_sign = sign[nonzero_idx]
-    changes = np.where((nonzero_sign[:-1] > 0) & (nonzero_sign[1:] < 0))[0]
-    zero_crossings = (nonzero_idx[changes] + nonzero_idx[changes + 1]) // 2
+    method = method.lower()
+    if method not in {"zero", "curvature"}:
+        raise ValueError("method must be 'zero' or 'curvature'")
+
+    if method == "zero":
+        # Identify zero crossings where the signal changes from positive to
+        # negative.  Zeros are ignored by using ``nan`` and compressing the array
+        # to regions of constant sign.
+        sign = np.sign(intensity)
+        sign = np.where(sign == 0, np.nan, sign)
+        nonzero_idx = np.where(~np.isnan(sign))[0]
+        if nonzero_idx.size == 0:
+            raise ValueError("No non-zero data points found")
+        nonzero_sign = sign[nonzero_idx]
+        changes = np.where((nonzero_sign[:-1] > 0) & (nonzero_sign[1:] < 0))[0]
+        zero_crossings = (nonzero_idx[changes] + nonzero_idx[changes + 1]) // 2
+
+        pairs: list[tuple[int, int]] = []
+        for i, zc in enumerate(zero_crossings):
+            center = field[zc]
+            left_bound = center - width
+            right_bound = center + width
+            if i > 0:
+                left_bound = max(left_bound, field[zero_crossings[i - 1]])
+            if i < len(zero_crossings) - 1:
+                right_bound = min(right_bound, field[zero_crossings[i + 1]])
+
+            left_mask = (field >= left_bound) & (field <= center)
+            right_mask = (field >= center) & (field <= right_bound)
+            left_idx = np.where(left_mask)[0]
+            right_idx = np.where(right_mask)[0]
+            if left_idx.size == 0 or right_idx.size == 0:
+                continue
+
+            pos_idx = left_idx[np.argmax(intensity[left_idx])]
+            neg_idx = right_idx[np.argmin(intensity[right_idx])]
+            pairs.append((int(pos_idx), int(neg_idx)))
+
+        n_pairs = expected // 2
+        if len(pairs) < n_pairs:
+            raise ValueError("Not enough peaks found in the data")
+
+        # Rank pairs by their peak-to-peak amplitude and select the most
+        # prominent
+        pairs = sorted(
+            pairs,
+            key=lambda p: abs(intensity[p[0]] - intensity[p[1]]),
+            reverse=True,
+        )[:n_pairs]
+
+        pairs.sort(key=lambda p: field[p[0]])
+        return pairs
+
+    # Curvature-based peak finder for absorption traces
+    deriv = np.gradient(intensity, field)
+    pos_peaks, _ = find_peaks(deriv)
+    neg_peaks, _ = find_peaks(-deriv)
+    if pos_peaks.size == 0 or neg_peaks.size == 0:
+        raise ValueError("Both positive and negative peaks are required in the data")
+
+    labeled = [*( (int(i), "pos") for i in pos_peaks ), *( (int(i), "neg") for i in neg_peaks )]
+    labeled.sort(key=lambda t: field[t[0]])
 
     pairs: list[tuple[int, int]] = []
-    for i, zc in enumerate(zero_crossings):
-        center = field[zc]
-        left_bound = center - width
-        right_bound = center + width
-        if i > 0:
-            left_bound = max(left_bound, field[zero_crossings[i - 1]])
-        if i < len(zero_crossings) - 1:
-            right_bound = min(right_bound, field[zero_crossings[i + 1]])
-
-        left_mask = (field >= left_bound) & (field <= center)
-        right_mask = (field >= center) & (field <= right_bound)
-        left_idx = np.where(left_mask)[0]
-        right_idx = np.where(right_mask)[0]
-        if left_idx.size == 0 or right_idx.size == 0:
-            continue
-
-        pos_idx = left_idx[np.argmax(intensity[left_idx])]
-        neg_idx = right_idx[np.argmin(intensity[right_idx])]
-        pairs.append((int(pos_idx), int(neg_idx)))
+    current_pos: int | None = None
+    for idx, kind in labeled:
+        if kind == "pos":
+            current_pos = idx
+        elif kind == "neg" and current_pos is not None:
+            pairs.append((current_pos, idx))
+            current_pos = None
 
     n_pairs = expected // 2
     if len(pairs) < n_pairs:
         raise ValueError("Not enough peaks found in the data")
 
-    # Rank pairs by their peak-to-peak amplitude and select the most prominent
     pairs = sorted(
         pairs,
-        key=lambda p: abs(intensity[p[0]] - intensity[p[1]]),
+        key=lambda p: abs(deriv[p[0]] - deriv[p[1]]),
         reverse=True,
     )[:n_pairs]
 

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -832,8 +832,13 @@ class SpanPeakSelector:
         if num is None:
             return
         try:
+            label = self.labels[self.current]
+            method = "curvature" if label.endswith("(absorption)") else "zero"
             pairs = auto_peak_finder(
-                self.spectrum.field, self.spectrum.intensity, expected=int(num)
+                self.spectrum.field,
+                self.spectrum.intensity,
+                expected=int(num),
+                method=method,
             )
         except ValueError as exc:
             messagebox.showerror("Peak Finder", str(exc))

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -82,6 +82,17 @@ def test_peak_finder_pairs():
     assert pairs == [(5, 7), (11, 13)]
 
 
+def test_peak_finder_curvature_on_absorption():
+    field = np.linspace(-5, 5, 10001)
+    intensity = np.exp(-field**2)
+    pairs = peak_finder(field, intensity, expected=2, method="curvature")
+    assert len(pairs) == 1
+    pos, neg = pairs[0]
+    # For a Gaussian the derivative extrema occur near ±1/sqrt(2)
+    assert np.isclose(field[pos], -1 / np.sqrt(2), atol=0.1)
+    assert np.isclose(field[neg], 1 / np.sqrt(2), atol=0.1)
+
+
 def test_baseline_correct_manual_and_auto():
     field = np.linspace(0, 10, 11)
     baseline = 0.5 * field + 1.0

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -128,6 +128,26 @@ def test_peak_finder_tabulates_positions():
     )
 
 
+def test_peak_finder_switches_to_curvature():
+    spectrum = ESRSpectrum(field=np.arange(5.0), intensity=np.array([0, 1, 0, -1, 0]))
+    selector = gui.SpanPeakSelector(spectrum)
+    selector.ax = None
+    selector.labels[0] = "Trace 1 (absorption)"
+    captured: dict[str, str] = {}
+
+    def fake_peak_finder(field, intensity, expected=4, width=15.0, method="zero"):
+        captured["method"] = method
+        return [(1, 3)]
+
+    with patch("esr_lab.gui.auto_peak_finder", new=fake_peak_finder), \
+        patch("esr_lab.gui.simpledialog.askinteger", return_value=2), \
+        patch("esr_lab.gui.messagebox.askyesno", return_value=True), \
+        patch("esr_lab.gui.messagebox.showinfo"):
+        selector.peak_finder()
+
+    assert captured["method"] == "curvature"
+
+
 def test_results_persist_across_analyses():
     spectrum = ESRSpectrum(field=np.arange(5.0), intensity=np.zeros(5))
     selector = gui.SpanPeakSelector(spectrum)


### PR DESCRIPTION
## Summary
- Extend `peak_finder` with a curvature-based mode for absorption spectra
- Automatically use curvature detection when an absorption trace is selected in the GUI
- Add regression tests for curvature peak finding and GUI mode switching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b07715ba3883248ca4415a4c81d34f