### PR TITLE
feat: auto-switch peak finder for absorption

### DIFF
--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -125,13 +125,18 @@ def peak_finder(
     intensity: np.ndarray,
     expected: int = 4,
     width: float = 15.0,
-    method: str = "zero",
+    method: str = "auto",
 ) -> list[tuple[int, int]]:
     """Automatically locate peak pairs in the provided data.
 
     Two approaches are supported:
 
-    ``method="zero"`` (default)
+    ``method="auto"`` (default)
+        Automatically chooses between the ``"zero"`` and ``"curvature"``
+        strategies based on the presence of zero crossings in ``intensity``.
+        If no zero crossings are found, the curvature approach is used.
+
+    ``method="zero"``
         Operates on derivative-mode data by locating zero crossings and
         searching for extrema in a window of ``±width`` around each crossing.
 
@@ -154,7 +159,7 @@ def peak_finder(
         Half width in magnetic-field units used around each zero crossing to
         determine the local maxima and minima.  The default of ``15.0`` mT
         mirrors the manual analysis range used in the GUI.  Ignored when
-        ``method="curvature"``.
+        ``"curvature"``.
     method:
         ``"zero"`` to base the detection on zero crossings of the provided
         trace (appropriate for derivative spectra) or ``"curvature"`` to analyse
@@ -177,10 +182,11 @@ def peak_finder(
         raise ValueError("Expected number of peaks must be an even integer >= 2")
 
     method = method.lower()
-    if method not in {"zero", "curvature"}:
-        raise ValueError("method must be 'zero' or 'curvature'")
+    if method not in {"zero", "curvature", "auto"}:
+        raise ValueError("method must be 'zero', 'curvature', or 'auto'")
 
-    if method == "zero":
+    zero_crossings: np.ndarray | None = None
+    if method in {"zero", "auto"}:
         # Identify zero crossings where the signal changes from positive to
         # negative.  Zeros are ignored by using ``nan`` and compressing the array
         # to regions of constant sign.
@@ -192,7 +198,12 @@ def peak_finder(
         nonzero_sign = sign[nonzero_idx]
         changes = np.where((nonzero_sign[:-1] > 0) & (nonzero_sign[1:] < 0))[0]
         zero_crossings = (nonzero_idx[changes] + nonzero_idx[changes + 1]) // 2
+        if zero_crossings.size == 0:
+            method = "curvature"
+        elif method == "auto":
+            method = "zero"
 
+    if method == "zero" and zero_crossings is not None:
         pairs: list[tuple[int, int]] = []
         for i, zc in enumerate(zero_crossings):
             center = field[zc]

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -832,13 +832,11 @@ class SpanPeakSelector:
         if num is None:
             return
         try:
-            label = self.labels[self.current]
-            method = "curvature" if label.endswith("(absorption)") else "zero"
             pairs = auto_peak_finder(
                 self.spectrum.field,
                 self.spectrum.intensity,
                 expected=int(num),
-                method=method,
+                method="auto",
             )
         except ValueError as exc:
             messagebox.showerror("Peak Finder", str(exc))

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -93,6 +93,16 @@ def test_peak_finder_curvature_on_absorption():
     assert np.isclose(field[neg], 1 / np.sqrt(2), atol=0.1)
 
 
+def test_peak_finder_auto_switches_to_curvature():
+    field = np.linspace(-5, 5, 10001)
+    intensity = np.exp(-field**2)
+    pairs = peak_finder(field, intensity, expected=2)
+    assert len(pairs) == 1
+    pos, neg = pairs[0]
+    assert np.isclose(field[pos], -1 / np.sqrt(2), atol=0.1)
+    assert np.isclose(field[neg], 1 / np.sqrt(2), atol=0.1)
+
+
 def test_baseline_correct_manual_and_auto():
     field = np.linspace(0, 10, 11)
     baseline = 0.5 * field + 1.0

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -128,11 +128,10 @@ def test_peak_finder_tabulates_positions():
     )
 
 
-def test_peak_finder_switches_to_curvature():
+def test_peak_finder_uses_auto_method():
     spectrum = ESRSpectrum(field=np.arange(5.0), intensity=np.array([0, 1, 0, -1, 0]))
     selector = gui.SpanPeakSelector(spectrum)
     selector.ax = None
-    selector.labels[0] = "Trace 1 (absorption)"
     captured: dict[str, str] = {}
 
     def fake_peak_finder(field, intensity, expected=4, width=15.0, method="zero"):
@@ -145,7 +144,7 @@ def test_peak_finder_switches_to_curvature():
         patch("esr_lab.gui.messagebox.showinfo"):
         selector.peak_finder()
 
-    assert captured["method"] == "curvature"
+    assert captured["method"] == "auto"
 
 
 def test_results_persist_across_analyses():


### PR DESCRIPTION
## Summary
- teach `peak_finder` to automatically fall back to curvature detection when no zero crossings exist
- simplify GUI peak finder to always use automatic method
- add regression tests for auto switching behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b07bda775c8324a6e28a7b3a01c025