### PR TITLE
feat: compute FWHM from peak separation

### DIFF
--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -66,9 +66,12 @@ def calc_fwhm(
     """Estimate the full width at half maximum from a peak pair.
 
     In derivative-mode ESR the distance between the positive and negative
-    extrema of an absorption line is proportional to its FWHM.  Once both peak
-    indices are known, the width can therefore be approximated simply as the
-    absolute difference of their field values.
+    extrema of an absorption line is not the FWHM itself.  For a Lorentzian
+    line shape the conversion factor between the peak-to-peak distance
+    :math:`\Delta H_{pp}` and the true FWHM is :math:`\sqrt{3}`.  The width is
+    therefore obtained by multiplying the separation of the extrema by this
+    factor.  The ``intensity`` array is currently unused but retained for API
+    compatibility.
 
     Parameters
     ----------
@@ -84,10 +87,11 @@ def calc_fwhm(
     Returns
     -------
     float
-        The absolute distance between the positive and negative peak positions.
+        The estimated FWHM assuming a Lorentzian line shape.
     """
 
-    return float(abs(field[pos_idx] - field[neg_idx]))
+    delta_h_pp = abs(field[pos_idx] - field[neg_idx])
+    return float(np.sqrt(3.0) * delta_h_pp)
 
 
 def calc_peak_to_peak(
@@ -429,8 +433,8 @@ FUNCTION_DETAILS: dict[str, tuple[str, sp.Expr | None]] = {
         None,
     ),
     "calc_fwhm": (
-        "Estimate the full width at half maximum (FWHM)",
-        sp.Eq(FWHM, sp.Abs(H_plus - H_minus)),
+        "Estimate the full width at half maximum (FWHM) assuming a Lorentzian line",
+        sp.Eq(FWHM, sp.sqrt(3) * sp.Abs(H_plus - H_minus)),
     ),
     "calc_peak_to_peak": (
         "Compute the peak-to-peak separation ΔH_pp",

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -28,8 +28,8 @@ def test_calc_fwhm_from_peaks():
 
     pos_idx, neg_idx = find_peak(field, intensity, -2, 2)
     width = calc_fwhm(field, intensity, pos_idx, neg_idx)
-
-    assert np.isclose(width, 2.0, atol=1e-3)
+    expected = 2.0 * np.sqrt(3.0)
+    assert np.isclose(width, expected, atol=1e-3)
 
 
 def test_calc_peak_to_peak_from_peaks():
@@ -40,6 +40,18 @@ def test_calc_peak_to_peak_from_peaks():
     width = calc_peak_to_peak(field, intensity, pos_idx, neg_idx)
 
     assert np.isclose(width, 2.0, atol=1e-3)
+
+
+def test_fwhm_relates_to_peak_to_peak():
+    field = np.linspace(-5, 5, 10001)
+    intensity = field * np.exp(-field**2 / 2)
+
+    pos_idx, neg_idx = find_peak(field, intensity, -2, 2)
+    fwhm = calc_fwhm(field, intensity, pos_idx, neg_idx)
+    dhpp = calc_peak_to_peak(field, intensity, pos_idx, neg_idx)
+
+    assert not np.isclose(fwhm, dhpp)
+    assert np.isclose(fwhm, np.sqrt(3.0) * dhpp, atol=1e-3)
 
 
 def test_fit_lorentzian_derivative_parameters():

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -81,6 +81,27 @@ def test_peak_to_peak_analysis():
     plt.close(fig)
 
 
+def test_fwhm_differs_from_peak_to_peak():
+    field = np.linspace(-5, 5, 10001)
+    intensity = field * np.exp(-field**2 / 2)
+    spec = ESRSpectrum(field=field, intensity=intensity)
+    selector = gui.SpanPeakSelector(spec)
+
+    with patch("esr_lab.gui.messagebox.showinfo"):
+        selector.onselect(-2.0, 2.0)
+    fwhm = selector.results[0]["width"]
+
+    selector.results.clear()
+    selector.analysis_func = gui.calc_peak_to_peak
+    selector.analysis_label = "\u0394H_pp"
+    with patch("esr_lab.gui.messagebox.showinfo"):
+        selector.onselect(-2.0, 2.0)
+    dhpp = selector.results[0]["width"]
+
+    assert not np.isclose(fwhm, dhpp)
+    assert np.isclose(fwhm, np.sqrt(3.0) * dhpp, atol=1e-3)
+
+
 def test_peak_finder_marks_peaks():
     spectrum = ESRSpectrum(field=np.arange(5.0), intensity=np.array([0, 1, 0, -1, 0]))
     selector = gui.SpanPeakSelector(spectrum)


### PR DESCRIPTION
## Summary
- Convert peak separation to a true FWHM by multiplying ΔH_pp by √3 for Lorentzian lines
- Expose updated FWHM expression in FUNCTION_DETAILS
- Add tests ensuring FWHM values differ from peak-to-peak widths and update GUI tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d04cb0e08324bc9371a4f5079c5f