### PR TITLE
Add grid lines to analysis table

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -1896,13 +1896,14 @@ class SpanPeakSelector:
                 borderwidth=1,
             )
             try:
+                # Draw light borders around each cell to form a simple grid
+                # separating the table entries in the analysis panel.
                 style.configure(
                     "Analysis.Treeview",
                     rowbordercolor="#d9d9d9",
                     rowborderwidth=1,
                     columnbordercolor="#d9d9d9",
                     columnborderwidth=1,
-                    columndashes=(2, 2),
                 )
             except tk.TclError:
                 pass


### PR DESCRIPTION
## Summary
- Draw light borders around analysis panel table cells
- Remove dashed styling for cleaner look

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2000cf5788324bc4d644fc8166cf3