### PR TITLE
Improve robustness of peak_finder for reversed derivative signals

### DIFF
--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -195,22 +195,30 @@ def peak_finder(
         raise ValueError("method must be 'zero', 'curvature', or 'auto'")
 
     zero_crossings: np.ndarray | None = None
+    flip = False
     if method in {"zero", "auto"}:
         # Identify zero crossings where the signal changes from positive to
         # negative.  Zeros are ignored by using ``nan`` and compressing the array
         # to regions of constant sign.
-        sign = np.sign(intensity)
+        work_intensity = intensity.copy()
+        sign = np.sign(work_intensity)
         sign = np.where(sign == 0, np.nan, sign)
         nonzero_idx = np.where(~np.isnan(sign))[0]
         if nonzero_idx.size == 0:
             raise ValueError("No non-zero data points found")
         nonzero_sign = sign[nonzero_idx]
+        if nonzero_sign[0] < 0:
+            flip = True
+            work_intensity = -work_intensity
+            sign = -sign
+            nonzero_sign = -nonzero_sign
         changes = np.where((nonzero_sign[:-1] > 0) & (nonzero_sign[1:] < 0))[0]
         zero_crossings = (nonzero_idx[changes] + nonzero_idx[changes + 1]) // 2
         if zero_crossings.size == 0:
             method = "curvature"
         elif method == "auto":
             method = "zero"
+        intensity = work_intensity
 
     if method == "zero" and zero_crossings is not None:
         pairs: list[tuple[int, int]] = []
@@ -232,7 +240,10 @@ def peak_finder(
 
             pos_idx = left_idx[np.argmax(intensity[left_idx])]
             neg_idx = right_idx[np.argmin(intensity[right_idx])]
-            pairs.append((int(pos_idx), int(neg_idx)))
+            if flip:
+                pairs.append((int(neg_idx), int(pos_idx)))
+            else:
+                pairs.append((int(pos_idx), int(neg_idx)))
 
         n_pairs = expected // 2
         if len(pairs) < n_pairs:

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -94,6 +94,42 @@ def test_peak_finder_pairs():
     assert pairs == [(5, 7), (11, 13)]
 
 
+def test_peak_finder_handles_reversed_derivative_polarity():
+    field = np.arange(20.0)
+    base_intensity = np.array(
+        [
+            0,
+            1,
+            0,
+            -1,
+            0,
+            2,
+            0,
+            -2,
+            0,
+            0,
+            0,
+            1.5,
+            0,
+            -1.5,
+            0,
+            0.5,
+            0,
+            -0.5,
+            0,
+            0,
+        ]
+    )
+
+    intensity = -base_intensity
+
+    pairs = peak_finder(field, intensity)
+
+    # Positive peaks now appear on the right and negative on the left, but the
+    # indices should still identify the correct peak locations.
+    assert pairs == [(7, 5), (13, 11)]
+
+
 def test_peak_finder_curvature_on_absorption():
     field = np.linspace(-5, 5, 10001)
     intensity = np.exp(-field**2)


### PR DESCRIPTION
## Summary
- Handle derivative traces with reversed polarity in `peak_finder`
- Add regression test for flipped derivative spectra

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2034ca6188324bf632dde73dc6ba6