### PR TITLE
Ensure baseline points are removed on cancel

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -1345,15 +1345,25 @@ class SpanPeakSelector:
                 dialog = tk.Toplevel(self.root)
                 dialog.title("Baseline Points")
                 tk.Label(dialog, textvariable=count_var).pack(padx=10, pady=5)
-                done = tk.BooleanVar(value=False)
+                confirmed = False
 
                 def confirm() -> None:
-                    done.set(True)
+                    nonlocal confirmed
+                    confirmed = True
                     dialog.destroy()
 
-                tk.Button(dialog, text="Confirm selection", command=confirm).pack(
-                    padx=10, pady=5
+                def cancel() -> None:
+                    dialog.destroy()
+
+                btn = tk.Frame(dialog)
+                btn.pack(padx=10, pady=5)
+                tk.Button(btn, text="Confirm selection", command=confirm).pack(
+                    side=tk.LEFT, padx=5
                 )
+                tk.Button(btn, text="Cancel", command=cancel).pack(
+                    side=tk.LEFT, padx=5
+                )
+                dialog.protocol("WM_DELETE_WINDOW", cancel)
 
                 editor = BaselinePointEditor(self.ax, field, intensity, degree)
 
@@ -1361,9 +1371,12 @@ class SpanPeakSelector:
                     count_var.set(f"Selected points: {len(editor.get_points())}")
 
                 editor.on_update = _update_count
-                dialog.wait_variable(done)
+                dialog.wait_window()
                 editor.disconnect()
                 pts = editor.get_points()
+                if not confirmed:
+                    editor.clear_artists()
+                    return
                 if len(pts) < 2:
                     editor.clear_artists()
                     messagebox.showwarning(

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -331,6 +331,81 @@ def test_baseline_correction_auto_cancel():
     plt.close(fig)
 
 
+def test_baseline_correction_manual_cancel():
+    spectrum = ESRSpectrum(
+        field=np.array([0.0, 1.0, 2.0]), intensity=np.array([1.0, 2.0, 3.0])
+    )
+    selector = gui.SpanPeakSelector(spectrum)
+    selector.root = object()
+    fig, selector.ax = plt.subplots()
+    (line,) = selector.ax.plot(spectrum.field, spectrum.intensity)
+    selector.trace_lines = [line]
+    selector.ax.figure.canvas.draw_idle = MagicMock()
+
+    editor = MagicMock()
+    editor.get_points.return_value = [(0.0, 1.0), (2.0, 3.0)]
+    editor.clear_artists = MagicMock()
+    editor.disconnect = MagicMock()
+
+    class DummyVar:
+        def __init__(self, value=None):
+            self.value = value
+
+        def set(self, value):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+    class DummyWidget:
+        def pack(self, *args, **kwargs):
+            pass
+
+    class DummyDialog:
+        def __init__(self, master=None):
+            pass
+
+        def title(self, *args, **kwargs):
+            pass
+
+        def protocol(self, *args, **kwargs):
+            pass
+
+        def destroy(self):
+            pass
+
+        def wait_window(self):
+            pass
+
+    with patch(
+        "esr_lab.gui.SpanPeakSelector._get_baseline_options", return_value=(True, False)
+    ), patch(
+        "esr_lab.gui.BaselinePointEditor", return_value=editor
+    ), patch(
+        "esr_lab.gui.tk.StringVar", side_effect=lambda *a, **k: DummyVar()
+    ), patch(
+        "esr_lab.gui.tk.BooleanVar", side_effect=lambda *a, **k: DummyVar()
+    ), patch(
+        "esr_lab.gui.tk.Label", side_effect=lambda *a, **k: DummyWidget()
+    ), patch(
+        "esr_lab.gui.tk.Button", side_effect=lambda *a, **k: DummyWidget()
+    ), patch(
+        "esr_lab.gui.tk.Frame", side_effect=lambda *a, **k: DummyWidget()
+    ), patch(
+        "esr_lab.gui.tk.Toplevel", side_effect=lambda *a, **k: DummyDialog()
+    ), patch(
+        "esr_lab.gui.messagebox.showwarning"
+    ) as warn, patch(
+        "esr_lab.gui.baseline_correct"
+    ) as bc:
+        selector.baseline_correction()
+        bc.assert_not_called()
+        editor.clear_artists.assert_called_once()
+        warn.assert_not_called()
+
+    plt.close(fig)
+
+
 def test_baseline_editor_clear():
     field = np.linspace(0.0, 2.0, 3)
     intensity = np.zeros(3)


### PR DESCRIPTION
## Summary
- remove baseline markers and preview line when baseline correction dialog is canceled
- add regression test for manual baseline cancellation

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b84b388580832496fe06265d32e687