### PR TITLE
feat: cache resonance fields across analyses

### DIFF
--- a/esr_lab/__init__.py
+++ b/esr_lab/__init__.py
@@ -12,6 +12,7 @@ from .analysis import (
     peak_finder,
     chi_square,
     baseline_correct,
+    get_resonance_field,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "peak_finder",
     "chi_square",
     "baseline_correct",
+    "get_resonance_field",
 ]

--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -2,9 +2,47 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import numpy as np
 from scipy.signal import find_peaks
 import sympy as sp
+
+# ---------------------------------------------------------------------------
+# Cache for previously determined resonance fields
+# ---------------------------------------------------------------------------
+# Stores resonance fields keyed by the base name of the analysed file.  The
+# cache is persisted alongside this module so values survive across sessions.
+H_RES_CACHE: dict[str, float] = {}
+H_RES_CACHE_FILE = Path(__file__).with_name("h_res_cache.json")
+
+
+def load_h_res_cache() -> None:
+    """Populate :data:`H_RES_CACHE` from the on-disk JSON cache if present."""
+
+    if H_RES_CACHE_FILE.exists():
+        try:
+            data = json.loads(H_RES_CACHE_FILE.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                H_RES_CACHE.update({str(k): float(v) for k, v in data.items()})
+        except (OSError, json.JSONDecodeError):
+            pass
+
+
+def save_h_res_cache() -> None:
+    """Serialise :data:`H_RES_CACHE` to :data:`H_RES_CACHE_FILE`."""
+
+    try:
+        H_RES_CACHE_FILE.write_text(
+            json.dumps(H_RES_CACHE), encoding="utf-8"
+        )
+    except OSError:
+        pass
+
+
+# Load existing cache on import so repeated analyses can reuse stored values.
+load_h_res_cache()
 
 
 def find_peak(
@@ -410,6 +448,38 @@ def fit_lorentzian_derivative(
     }
 
     return (float(h_res), float(delta), float(A), float(B)), stats
+
+
+def get_resonance_field(
+    path: str | Path,
+    field: np.ndarray,
+    intensity: np.ndarray,
+    p0: tuple[float, float, float, float] | None = None,
+) -> float:
+    """Return the resonance field for ``path`` using a cached value when available.
+
+    Parameters
+    ----------
+    path:
+        Path to the analysed trace.  The base name of the file (portion before
+        the first underscore) is used as the cache key.
+    field, intensity:
+        Arrays containing the spectral data used for the fit when a cached value
+        is unavailable.
+    p0:
+        Optional initial guess forwarded to :func:`fit_lorentzian_derivative`
+        when a fit is performed.
+    """
+
+    base = Path(path).stem.split("_")[0]
+    if base in H_RES_CACHE:
+        return H_RES_CACHE[base]
+
+    params, _stats = fit_lorentzian_derivative(field, intensity, p0=p0)
+    h_res = params[0]
+    H_RES_CACHE[base] = h_res
+    save_h_res_cache()
+    return h_res
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,3 +1,4 @@
+import json
 import numpy as np
 import pytest
 
@@ -9,6 +10,7 @@ from esr_lab import (
     peak_finder,
     chi_square,
     baseline_correct,
+    get_resonance_field,
 )
 
 
@@ -126,3 +128,40 @@ def test_baseline_correct_manual_and_auto():
 
     corrected_auto, _ = baseline_correct(field, intensity)
     assert np.allclose(corrected_auto, signal)
+
+
+def test_get_resonance_field_uses_cache(tmp_path, monkeypatch):
+    import esr_lab.analysis as analysis
+
+    # Use a temporary cache file to avoid interfering with real data
+    cache_file = tmp_path / "cache.json"
+    monkeypatch.setattr(analysis, "H_RES_CACHE_FILE", cache_file)
+    analysis.H_RES_CACHE.clear()
+    analysis.load_h_res_cache()
+
+    # Stub ``fit_lorentzian_derivative`` to track invocations
+    calls = {"n": 0}
+
+    def fake_fit(field, intensity, p0=None):
+        calls["n"] += 1
+        return (1.23, 0.0, 0.0, 0.0), {}
+
+    monkeypatch.setattr(analysis, "fit_lorentzian_derivative", fake_fit)
+
+    field = np.linspace(-5, 5, 11)
+    intensity = np.zeros_like(field)
+
+    # First call performs the fit and stores the result
+    path1 = tmp_path / "sample_001.csv"
+    h1 = get_resonance_field(path1, field, intensity)
+    assert calls["n"] == 1
+
+    # Second call with same base name uses cached value
+    path2 = tmp_path / "sample_002.csv"
+    h2 = get_resonance_field(path2, field, intensity)
+    assert calls["n"] == 1
+    assert h1 == h2 == 1.23
+
+    # Cache persisted to disk
+    data = json.loads(cache_file.read_text())
+    assert data["sample"] == 1.23


### PR DESCRIPTION
## Summary
- persist resonance-field estimates in `H_RES_CACHE` for reuse across traces
- add `get_resonance_field` helper that consults and updates the cache
- expose `get_resonance_field` in the public package interface

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8760a6e008324aba747f4b5f06d0c