### PR TITLE
Add absorption peak finding using SciPy

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -20,6 +20,7 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolb
 from matplotlib.widgets import SpanSelector
 from typing import Callable
 from scipy.integrate import cumulative_trapezoid
+from scipy.signal import find_peaks
 import sympy as sp
 import copy
 
@@ -910,16 +911,18 @@ class SpanPeakSelector:
             num = 2
         if num is None:
             return
-        try:
-            peaks = auto_peak_finder(
-                self.spectrum.field,
-                self.spectrum.intensity,
-                expected=int(num) * 2,
-                method="curvature",
-            )
-        except ValueError as exc:
-            messagebox.showerror("Peak Finder", str(exc))
+        # Locate local maxima in the absorption trace. ``find_peaks`` returns
+        # all peak indices which are then ranked by their height to select the
+        # most prominent ``num`` peaks.
+        peaks, _ = find_peaks(self.spectrum.intensity)
+        if peaks.size < int(num):
+            messagebox.showerror("Peak Finder", "Not enough peaks found in the data")
             return
+
+        top = np.argsort(self.spectrum.intensity[peaks])[::-1][: int(num)]
+        peaks = peaks[top]
+        peaks.sort()
+        peaks = [int(p) for p in peaks]
 
         markers: list[Line2D] = []
         if self.ax is not None:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -182,7 +182,7 @@ def test_peak_finder_absorption_marks_peaks():
 
     selector.ax.plot = MagicMock(side_effect=fake_plot)
 
-    with patch("esr_lab.gui.auto_peak_finder", return_value=[1, 3]), \
+    with patch("esr_lab.gui.find_peaks", return_value=(np.array([1, 3]), {})), \
         patch("esr_lab.gui.simpledialog.askinteger", return_value=2), \
         patch("esr_lab.gui.messagebox.askyesno", return_value=True), \
         patch("esr_lab.gui.messagebox.showinfo"):
@@ -201,7 +201,7 @@ def test_peak_finder_absorption_tabulates_positions():
     tree = MagicMock()
     tree.get_children.return_value = []
     selector.peak_tree = tree
-    with patch("esr_lab.gui.auto_peak_finder", return_value=[1, 3]), \
+    with patch("esr_lab.gui.find_peaks", return_value=(np.array([1, 3]), {})), \
         patch("esr_lab.gui.simpledialog.askinteger", return_value=2), \
         patch("esr_lab.gui.messagebox.askyesno", return_value=True), \
         patch("esr_lab.gui.messagebox.showinfo"):
@@ -213,25 +213,30 @@ def test_peak_finder_absorption_tabulates_positions():
     )
 
 
-def test_peak_finder_absorption_uses_curvature_method():
+def test_peak_finder_absorption_cancel():
     spectrum = ESRSpectrum(field=np.arange(5.0), intensity=np.array([0, 1, 0, 2, 0]))
     selector = gui.SpanPeakSelector(spectrum)
-    selector.ax = None
-    captured: dict[str, int | str] = {}
+    fig, selector.ax = plt.subplots()
 
-    def fake_peak_finder(field, intensity, expected=4, width=15.0, method="zero"):
-        captured["method"] = method
-        captured["expected"] = expected
-        return [2]
+    markers: list[MagicMock] = []
 
-    with patch("esr_lab.gui.auto_peak_finder", new=fake_peak_finder), \
-        patch("esr_lab.gui.simpledialog.askinteger", return_value=1), \
-        patch("esr_lab.gui.messagebox.askyesno", return_value=True), \
+    def fake_plot(*args, **kwargs):
+        m = MagicMock()
+        markers.append(m)
+        return [m]
+
+    selector.ax.plot = MagicMock(side_effect=fake_plot)
+
+    with patch("esr_lab.gui.find_peaks", return_value=(np.array([1, 3]), {})), \
+        patch("esr_lab.gui.simpledialog.askinteger", return_value=2), \
+        patch("esr_lab.gui.messagebox.askyesno", return_value=False), \
         patch("esr_lab.gui.messagebox.showinfo"):
         selector.peak_finder_absorption()
 
-    assert captured["method"] == "curvature"
-    assert captured["expected"] == 2
+    assert selector.ax.plot.call_count == 2
+    assert all(m.remove.call_count == 1 for m in markers)
+    assert selector.abs_peaks == []
+    plt.close(fig)
 
 
 def test_results_persist_across_analyses():


### PR DESCRIPTION
## Summary
- Add `peak_finder_absorption` that uses `scipy.signal.find_peaks` to detect the strongest absorption maxima, display markers for confirmation, and store accepted peaks
- Extend GUI tests to cover absorption peak marker placement, user confirmation, and table updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9bf0906348324981a1ea4f39fa55a