### PR TITLE
Add g-factor calculation and GUI support

### DIFF
--- a/esr_lab/__init__.py
+++ b/esr_lab/__init__.py
@@ -12,6 +12,7 @@ from .analysis import (
     peak_finder,
     chi_square,
     baseline_correct,
+    calc_g,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "peak_finder",
     "chi_square",
     "baseline_correct",
+    "calc_g",
 ]

--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import numpy as np
 from scipy.signal import find_peaks
 import sympy as sp
+from scipy.constants import h, physical_constants
+
+MU_B = physical_constants["Bohr magneton"][0]
 
 
 def find_peak(
@@ -122,6 +125,28 @@ def calc_peak_to_peak(
     """
 
     return float(abs(field[pos_idx] - field[neg_idx]))
+
+
+def calc_g(h_res: float, frequency: float) -> float:
+    r"""Calculate the g-factor from the resonance field and microwave frequency.
+
+    Parameters
+    ----------
+    h_res:
+        Resonance field of the peak in millitesla.
+    frequency:
+        Microwave frequency in gigahertz.
+
+    Returns
+    -------
+    float
+        The dimensionless g-factor computed via
+        :math:`g = h\nu/(\mu_B H_{res})`.
+    """
+
+    freq_hz = frequency * 1e9
+    h_res_t = h_res * 1e-3
+    return float(h * freq_hz / (MU_B * h_res_t))
 
 
 def peak_finder(
@@ -421,6 +446,7 @@ A, B = sp.symbols("A B")
 I = sp.Function("I")
 L_abs = sp.Function("L_abs")
 L_disp = sp.Function("L_disp")
+g_sym, nu, mu_B_sym, h_sym = sp.symbols("g nu mu_B h")
 
 # Symbols for displaying derivative expressions as textbook-style fractions
 dI_H, dL_abs_H, dL_disp_H, dH = sp.symbols(
@@ -447,6 +473,10 @@ FUNCTION_DETAILS: dict[str, tuple[str, sp.Expr | None]] = {
     "baseline_correct": (
         "Perform a polynomial baseline correction",
         None,
+    ),
+    "calc_g": (
+        "Compute the g-factor from resonance field and frequency",
+        sp.Eq(g_sym, h_sym * nu / (mu_B_sym * H)),
     ),
     "fit_lorentzian_derivative": (
         "Fit a derivative ESR line to a Lorentzian derivative model",

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -30,6 +30,7 @@ from .analysis import (
     calc_peak_to_peak,
     peak_finder as auto_peak_finder,
     baseline_correct,
+    calc_g,
     FUNCTION_DETAILS,
 )
 from .io import ESRLoader
@@ -537,6 +538,7 @@ class SpanPeakSelector:
         self.meta_label: tk.Label | None = None
         self.metadata_text: str = ""
         self.delete_btn: tk.Button | ttk.Button | None = None
+        self.g_btn: tk.Button | ttk.Button | None = None
         self.undo_btn: tk.Button | ttk.Button | None = None
         self._history: list[dict[str, object]] = []
         # Keep track of which peak (1 or 2) the user is analysing.
@@ -1178,6 +1180,37 @@ class SpanPeakSelector:
             )
 
     # ------------------------------------------------------------------
+    def calculate_g(self) -> None:
+        """Compute the g-factor for fitted peaks using metadata frequency."""
+
+        if not self.lorentz_results:
+            messagebox.showinfo("Calculate g", "No Lorentzian fits available")
+            return
+
+        freq = None
+        if self.spectrum.metadata is not None:
+            freq = self.spectrum.metadata.get("Frequency")
+        if freq is None:
+            messagebox.showinfo("Calculate g", "Frequency metadata not available")
+            return
+
+        try:
+            freq_val = float(freq)
+        except Exception:
+            messagebox.showinfo("Calculate g", "Invalid frequency value")
+            return
+
+        lines: list[str] = []
+        for r in self.lorentz_results:
+            h_res = float(r.get("h_res", 0.0))
+            g_val = calc_g(h_res, freq_val)
+            r["g"] = g_val
+            lines.append(f"Peak {r['peak']}: g={g_val:.3f}")
+
+        self._refresh_tables()
+        messagebox.showinfo("Calculate g", "\n".join(lines))
+
+    # ------------------------------------------------------------------
     def _get_baseline_options(self) -> tuple[bool, bool] | None:
         """Return user-selected baseline options.
 
@@ -1531,6 +1564,8 @@ class SpanPeakSelector:
             for item in self.lorentz_tree.get_children():
                 self.lorentz_tree.delete(item)
             for r in self.lorentz_results:
+                g_val = r.get("g")
+                g_str = f"{g_val:.3f}" if isinstance(g_val, (int, float)) else ""
                 self.lorentz_tree.insert(
                     "",
                     tk.END,
@@ -1541,6 +1576,7 @@ class SpanPeakSelector:
                         f"{r['delta']:.3f}",
                         f"{r['A']:.3f}",
                         f"{r['B']:.3f}",
+                        g_str,
                     ),
                 )
 
@@ -2138,6 +2174,13 @@ class SpanPeakSelector:
         button_row3 = tk.Frame(control_frame)
         button_row3.pack(fill=tk.X, padx=5, pady=(2, 5))
 
+        self.g_btn = ButtonCls(
+            button_row3,
+            text="Calculate g",
+            command=self.calculate_g,
+            **button_kwargs,
+        )
+
         self.undo_btn = ButtonCls(
             button_row3,
             text="Undo",
@@ -2197,7 +2240,7 @@ class SpanPeakSelector:
         tk.Label(
             lorentz_frame, text="Lorentzian Fits", font=("TkDefaultFont", 10, "bold")
         ).pack(anchor="w", padx=5, pady=(5, 0))
-        lorentz_columns = ("analysis", "peak", "h_res", "delta", "A", "B")
+        lorentz_columns = ("analysis", "peak", "h_res", "delta", "A", "B", "g")
         self.lorentz_tree = ttk.Treeview(
             lorentz_frame, columns=lorentz_columns, show="headings", height=5
         )
@@ -2208,6 +2251,7 @@ class SpanPeakSelector:
             "delta": "Delta",
             "A": "A",
             "B": "B",
+            "g": "g",
         }
         for col, text in lorentz_headings.items():
             self.lorentz_tree.heading(col, text=text)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from scipy.constants import h, physical_constants
 
 from esr_lab import (
     find_peak,
@@ -9,6 +10,7 @@ from esr_lab import (
     peak_finder,
     chi_square,
     baseline_correct,
+    calc_g,
 )
 
 
@@ -126,3 +128,10 @@ def test_baseline_correct_manual_and_auto():
 
     corrected_auto, _ = baseline_correct(field, intensity)
     assert np.allclose(corrected_auto, signal)
+
+
+def test_calc_g_expected_value():
+    mu_B = physical_constants["Bohr magneton"][0]
+    g_val = calc_g(339.0, 9.5)
+    expected = h * 9.5e9 / (mu_B * 0.339)
+    assert np.isclose(g_val, expected)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -414,6 +414,29 @@ def test_lorentzian_fit_results_tabulated():
     plt.close(fig)
 
 
+def test_calculate_g_updates_results():
+    spectrum = ESRSpectrum(
+        field=np.linspace(-1, 1, 5),
+        intensity=np.zeros(5),
+        metadata={"Frequency": 9.5},
+    )
+    selector = gui.SpanPeakSelector(spectrum)
+    selector.lorentz_results = [
+        {"analysis": "Lorentzian", "peak": 1, "h_res": 339.0, "delta": 1.0, "A": 1.0, "B": 0.0}
+    ]
+    tree = MagicMock()
+    tree.get_children.return_value = []
+    selector.lorentz_tree = tree
+    with patch("esr_lab.gui.messagebox.showinfo") as info:
+        selector.calculate_g()
+        info.assert_called_once()
+    g_val = selector.lorentz_results[0]["g"]
+    expected = gui.calc_g(339.0, 9.5)
+    assert np.isclose(g_val, expected)
+    tree.insert.assert_called_once()
+    assert tree.insert.call_args.kwargs["values"][-1] == f"{g_val:.3f}"
+
+
 def test_toolbar_has_default_tools_without_subplots():
     tools = [item[0] for item in gui.NavigationToolbarNoSubplots.toolitems if item]
     assert "Subplots" not in tools


### PR DESCRIPTION
## Summary
- add calc_g utility using Planck's constant and Bohr magneton
- expose g-factor calculation via new "Calculate g" button and table column
- test g-factor computation in analysis and GUI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9c0f5135c83249f31138c06813009