### PR TITLE
Update absorption peak storage on trace integration

### DIFF
--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -1595,6 +1595,7 @@ class SpanPeakSelector:
         self.lorentz_all.append([])
         self.ranges_all.append([])
         self.auto_peaks_all.append([])
+        self.abs_peaks_all.append([])
 
         if (
             self.trace_combo is None


### PR DESCRIPTION
## Summary
- ensure `integrate_trace` maintains `abs_peaks_all` alongside other trace metadata

## Testing
- `python - <<'PY'
import types, sys, importlib.machinery, importlib.util, pathlib
import numpy as np
import matplotlib
matplotlib.use('Agg')
import matplotlib.pyplot as plt
from unittest.mock import patch, MagicMock
pkg_name = 'esr_lab'
package = types.ModuleType(pkg_name)
package.__path__ = [str(pathlib.Path('esr_lab').resolve())]
sys.modules[pkg_name] = package
loader = importlib.machinery.SourceFileLoader(f'{pkg_name}.gui', 'esr_lab/gui.py')
spec = importlib.util.spec_from_loader(loader.name, loader)
module = importlib.util.module_from_spec(spec)
loader.exec_module(module)
from esr_lab.spectrum import ESRSpectrum
field = np.linspace(-5, 5, 11); intensity = np.sin(field)
selector = module.SpanPeakSelector(ESRSpectrum(field=field, intensity=intensity))
fig, selector.ax = plt.subplots(); (line,) = selector.ax.plot(field, intensity)
selector.trace_lines = [line]; selector.ax.figure.canvas.draw_idle = MagicMock()
selector.integrate_trace()
new_label = selector.labels[-1]
selector.trace_var = MagicMock(get=lambda: new_label)
selector._on_trace_change()
with patch('esr_lab.gui.simpledialog.askinteger', return_value=1), patch('esr_lab.gui.messagebox.askyesno', return_value=True), patch('esr_lab.gui.messagebox.showinfo'), patch('esr_lab.gui.find_peaks', return_value=(np.array([5]), {})):
    selector.peak_finder_absorption()
print('abs_peaks:', selector.abs_peaks)
PY`
- `pytest -q` (fails: SyntaxError in tests/test_analysis.py and esr_lab/__init__.py)`

------
https://chatgpt.com/codex/tasks/task_e_68bb18387a688324b9131f90b0f86813