### PR TITLE
Add g-factor calculation and expose via API

### DIFF
--- a/esr_lab/__init__.py
+++ b/esr_lab/__init__.py
@@ -12,11 +12,8 @@ from .analysis import (
     peak_finder,
     chi_square,
     baseline_correct,
-<<<<<<< HEAD
     get_resonance_field,
-=======
     calc_g,
->>>>>>> ad91b7b (Add g-factor calculation and GUI support)
 )
 
 __all__ = [
@@ -31,9 +28,6 @@ __all__ = [
     "peak_finder",
     "chi_square",
     "baseline_correct",
-<<<<<<< HEAD
     "get_resonance_field",
-=======
     "calc_g",
->>>>>>> ad91b7b (Add g-factor calculation and GUI support)
 ]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -10,11 +10,8 @@ from esr_lab import (
     peak_finder,
     chi_square,
     baseline_correct,
-<<<<<<< HEAD
     get_resonance_field,
-=======
     calc_g,
->>>>>>> ad91b7b (Add g-factor calculation and GUI support)
 )
 
 
@@ -134,7 +131,6 @@ def test_baseline_correct_manual_and_auto():
     assert np.allclose(corrected_auto, signal)
 
 
-<<<<<<< HEAD
 def test_get_resonance_field_always_fits(monkeypatch):
     import esr_lab.analysis as analysis
 
@@ -154,10 +150,10 @@ def test_get_resonance_field_always_fits(monkeypatch):
     h2 = get_resonance_field(path, field, intensity)
     assert calls["n"] == 2
     assert h1 == h2 == 1.23
-=======
+
+
 def test_calc_g_expected_value():
     mu_B = physical_constants["Bohr magneton"][0]
     g_val = calc_g(339.0, 9.5)
     expected = h * 9.5e9 / (mu_B * 0.339)
     assert np.isclose(g_val, expected)
->>>>>>> ad91b7b (Add g-factor calculation and GUI support)


### PR DESCRIPTION
## Summary
- expose `calc_g` through package init
- add regression test for `calc_g`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb33efab588324856604d4fb20ee87