### PR TITLE
Add Lorentzian area integration

### DIFF
--- a/esr_lab/__init__.py
+++ b/esr_lab/__init__.py
@@ -15,6 +15,7 @@ from .analysis import (
     baseline_correct,
     get_resonance_field,
     calc_g,
+    calc_lorentzian_area,
 )
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     "baseline_correct",
     "get_resonance_field",
     "calc_g",
+    "calc_lorentzian_area",
 ]

--- a/esr_lab/analysis.py
+++ b/esr_lab/analysis.py
@@ -152,6 +152,34 @@ def calc_g(h_res: float, frequency: float) -> float:
     return float(h * freq_hz / (MU_B * h_res_t))
 
 
+def calc_lorentzian_area(delta: float, amplitude: float) -> float:
+    """Calculate the area under a Lorentzian absorption line.
+
+    The absorption model used in :func:`fit_lorentzian_absorption` is
+
+    ``I(H) = A * delta**2 / ((H - H_res)**2 + delta**2) + C``.
+
+    The integral of the Lorentzian part (without the constant offset ``C``)
+    over the entire field range is ``pi * A * delta``.  This helper returns the
+    corresponding area for given half width at half maximum ``delta`` and
+    amplitude ``A``.
+
+    Parameters
+    ----------
+    delta:
+        Half width at half maximum (HWHM).
+    amplitude:
+        Amplitude ``A`` of the Lorentzian line.
+
+    Returns
+    -------
+    float
+        Area of the absorption Lorentzian.
+    """
+
+    return float(np.pi * amplitude * delta)
+
+
 def peak_finder(
     field: np.ndarray,
     intensity: np.ndarray,
@@ -525,6 +553,7 @@ def get_resonance_field(
 H_plus, H_minus = sp.symbols("H_+ H_-")
 FWHM, ΔH_pp, H = sp.symbols("FWHM ΔH_pp H")
 A, B = sp.symbols("A B")
+delta_sym, Area = sp.symbols("delta Area")
 I = sp.Function("I")
 L_abs = sp.Function("L_abs")
 L_disp = sp.Function("L_disp")
@@ -559,6 +588,10 @@ FUNCTION_DETAILS: dict[str, tuple[str, sp.Expr | None]] = {
     "calc_g": (
         "Compute the g-factor from resonance field and frequency",
         sp.Eq(g_sym, h_sym * nu / (mu_B_sym * H)),
+    ),
+    "calc_lorentzian_area": (
+        "Calculate the area under a Lorentzian absorption line",
+        sp.Eq(Area, sp.pi * A * delta_sym),
     ),
     "fit_lorentzian_derivative": (
         "Fit a derivative ESR line to a Lorentzian derivative model",

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -33,6 +33,7 @@ from .analysis import (
     peak_finder as auto_peak_finder,
     baseline_correct,
     calc_g,
+    calc_lorentzian_area,
     FUNCTION_DETAILS,
 )
 from .io import ESRLoader
@@ -546,6 +547,7 @@ class SpanPeakSelector:
         self.metadata_text: str = ""
         self.delete_btn: tk.Button | ttk.Button | None = None
         self.g_btn: tk.Button | ttk.Button | None = None
+        self.area_btn: tk.Button | ttk.Button | None = None
         self.undo_btn: tk.Button | ttk.Button | None = None
         self._history: list[dict[str, object]] = []
         # Keep track of which peak (1 or 2) the user is analysing.
@@ -1191,6 +1193,7 @@ class SpanPeakSelector:
             "delta": float(delta),
             "A": float(A),
             "B": float(B),
+            "kind": "absorption" if is_absorption else "derivative",
         }
         self.lorentz_results.append(result)
         if self.lorentz_tree is not None:
@@ -1385,6 +1388,31 @@ class SpanPeakSelector:
 
         self._refresh_tables()
         messagebox.showinfo("Calculate g", "\n".join(lines))
+
+    # ------------------------------------------------------------------
+    def calculate_area(self) -> None:
+        """Calculate the area for fitted Lorentzian absorption peaks."""
+
+        if not self.lorentz_results:
+            messagebox.showinfo("Area Integral", "No Lorentzian fits available")
+            return
+
+        lines: list[str] = []
+        for r in self.lorentz_results:
+            if r.get("kind") != "absorption":
+                continue
+            delta = float(r.get("delta", 0.0))
+            amp = float(r.get("A", 0.0))
+            area = calc_lorentzian_area(delta, amp)
+            r["area"] = area
+            lines.append(f"Peak {r['peak']}: area={area:.3f}")
+
+        if not lines:
+            messagebox.showinfo("Area Integral", "No absorption Lorentzian fits available")
+            return
+
+        self._refresh_tables()
+        messagebox.showinfo("Area Integral", "\n".join(lines))
 
     # ------------------------------------------------------------------
     def _get_baseline_options(self) -> tuple[bool, bool] | None:
@@ -1770,6 +1798,10 @@ class SpanPeakSelector:
             for r in self.lorentz_results:
                 g_val = r.get("g")
                 g_str = f"{g_val:.3f}" if isinstance(g_val, (int, float)) else ""
+                area_val = r.get("area")
+                area_str = (
+                    f"{area_val:.3f}" if isinstance(area_val, (int, float)) else ""
+                )
                 self.lorentz_tree.insert(
                     "",
                     tk.END,
@@ -1780,6 +1812,7 @@ class SpanPeakSelector:
                         f"{r['delta']:.3f}",
                         f"{r['A']:.3f}",
                         f"{r['B']:.3f}",
+                        area_str,
                         g_str,
                     ),
                 )
@@ -2368,6 +2401,13 @@ class SpanPeakSelector:
             **button_kwargs,
         )
 
+        self.area_btn = ButtonCls(
+            button_row3,
+            text="Area Integral",
+            command=self.calculate_area,
+            **button_kwargs,
+        )
+
         self.undo_btn = ButtonCls(
             button_row3,
             text="Undo",
@@ -2427,7 +2467,7 @@ class SpanPeakSelector:
         tk.Label(
             lorentz_frame, text="Lorentzian Fits", font=("TkDefaultFont", 10, "bold")
         ).pack(anchor="w", padx=5, pady=(5, 0))
-        lorentz_columns = ("analysis", "peak", "h_res", "delta", "A", "B", "g")
+        lorentz_columns = ("analysis", "peak", "h_res", "delta", "A", "B", "area", "g")
         self.lorentz_tree = ttk.Treeview(
             lorentz_frame, columns=lorentz_columns, show="headings", height=5
         )
@@ -2438,6 +2478,7 @@ class SpanPeakSelector:
             "delta": "Delta",
             "A": "A",
             "B": "B",
+            "area": "Area",
             "g": "g",
         }
         for col, text in lorentz_headings.items():

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -13,6 +13,7 @@ from esr_lab import (
     baseline_correct,
     get_resonance_field,
     calc_g,
+    calc_lorentzian_area,
 )
 
 
@@ -170,3 +171,11 @@ def test_calc_g_expected_value():
     g_val = calc_g(339.0, 9.5)
     expected = h * 9.5e9 / (mu_B * 0.339)
     assert np.isclose(g_val, expected)
+
+
+def test_calc_lorentzian_area_expected_value():
+    delta = 2.0
+    amp = 3.0
+    area = calc_lorentzian_area(delta, amp)
+    expected = np.pi * amp * delta
+    assert np.isclose(area, expected)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -562,7 +562,15 @@ def test_lorentzian_fit_results_tabulated():
         selector.fit_lorentzian()
         fit.assert_called_once()
     assert selector.lorentz_results == [
-        {"analysis": "Lorentzian", "peak": 1, "h_res": 0.0, "delta": 1.0, "A": 2.0, "B": 3.0}
+        {
+            "analysis": "Lorentzian",
+            "peak": 1,
+            "h_res": 0.0,
+            "delta": 1.0,
+            "A": 2.0,
+            "B": 3.0,
+            "kind": "derivative",
+        }
     ]
     selector.lorentz_tree.insert.assert_called_once()
     plt.close(fig)
@@ -604,7 +612,15 @@ def test_calculate_g_updates_results():
     )
     selector = gui.SpanPeakSelector(spectrum)
     selector.lorentz_results = [
-        {"analysis": "Lorentzian", "peak": 1, "h_res": 339.0, "delta": 1.0, "A": 1.0, "B": 0.0}
+        {
+            "analysis": "Lorentzian",
+            "peak": 1,
+            "h_res": 339.0,
+            "delta": 1.0,
+            "A": 1.0,
+            "B": 0.0,
+            "kind": "absorption",
+        }
     ]
     tree = MagicMock()
     tree.get_children.return_value = []
@@ -617,6 +633,33 @@ def test_calculate_g_updates_results():
     assert np.isclose(g_val, expected)
     tree.insert.assert_called_once()
     assert tree.insert.call_args.kwargs["values"][-1] == f"{g_val:.3f}"
+
+
+def test_calculate_area_updates_results():
+    spectrum = ESRSpectrum(field=np.linspace(-1, 1, 5), intensity=np.zeros(5))
+    selector = gui.SpanPeakSelector(spectrum)
+    selector.lorentz_results = [
+        {
+            "analysis": "Lorentzian",
+            "peak": 1,
+            "h_res": 0.0,
+            "delta": 2.0,
+            "A": 3.0,
+            "B": 0.0,
+            "kind": "absorption",
+        }
+    ]
+    tree = MagicMock()
+    tree.get_children.return_value = []
+    selector.lorentz_tree = tree
+    with patch("esr_lab.gui.messagebox.showinfo") as info:
+        selector.calculate_area()
+        info.assert_called_once()
+    area_val = selector.lorentz_results[0]["area"]
+    expected = gui.calc_lorentzian_area(2.0, 3.0)
+    assert np.isclose(area_val, expected)
+    tree.insert.assert_called_once()
+    assert tree.insert.call_args.kwargs["values"][-2] == f"{area_val:.3f}"
 
 
 def test_toolbar_has_default_tools_without_subplots():
@@ -771,10 +814,26 @@ def test_spectra_comparison_tabulated():
     ]
     selector.lorentz_all = [
         [
-            {"analysis": "Lorentzian", "peak": 1, "h_res": 10.0, "delta": 0, "A": 0, "B": 0}
+            {
+                "analysis": "Lorentzian",
+                "peak": 1,
+                "h_res": 10.0,
+                "delta": 0,
+                "A": 0,
+                "B": 0,
+                "kind": "derivative",
+            }
         ],
         [
-            {"analysis": "Lorentzian", "peak": 1, "h_res": 12.0, "delta": 0, "A": 0, "B": 0}
+            {
+                "analysis": "Lorentzian",
+                "peak": 1,
+                "h_res": 12.0,
+                "delta": 0,
+                "A": 0,
+                "B": 0,
+                "kind": "derivative",
+            }
         ],
     ]
 


### PR DESCRIPTION
## Summary
- add `calc_lorentzian_area` utility for computing the integral of Lorentzian absorption peaks
- expose area calculation via new GUI button and table column
- document area function in help metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bef617ddac83249bd699432f02d67b