### PR TITLE
Add automated spectra analysis button

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This project is at an early stage — we’re starting from the basics and will 
 - Baseline correction for data refinement
 - Trace integration, get absorption spectrum for absorption area analysis
 - g-factor calculation from H_res, and metadata
+- One-click Analyze Spectra button running peak finding, ΔH_pp, FWHM,
+  Lorentzian fits and g-factor calculation
 - gyromagnetic ratio from calculated g-factor
 
 ## Requirements

--- a/esr_lab/gui.py
+++ b/esr_lab/gui.py
@@ -537,6 +537,7 @@ class SpanPeakSelector:
         self.peak_tree: ttk.Treeview | None = None
         self.tree: ttk.Treeview | None = None
         self.lorentz_tree: ttk.Treeview | None = None
+        self.analyze_btn: tk.Button | ttk.Button | None = None
         self.analyse_btn: tk.Button | ttk.Button | None = None
         self.dhpp_btn: tk.Button | ttk.Button | None = None
         self.find_btn: tk.Button | ttk.Button | None = None
@@ -1397,6 +1398,19 @@ class SpanPeakSelector:
 
         self._refresh_tables()
         messagebox.showinfo("Calculate g", "\n".join(lines))
+
+    # ------------------------------------------------------------------
+    def analyze_spectra(self) -> None:
+        """Run peak finding, linewidth, fitting and g-factor analysis."""
+
+        try:
+            self.peak_finder()
+            self.start_peak_to_peak()
+            self.start_analysis()
+            self.fit_lorentzian()
+            self.calculate_g()
+        except Exception as exc:
+            messagebox.showerror("Analyze Spectra", str(exc))
 
     # ------------------------------------------------------------------
     def calculate_area(self) -> None:
@@ -2371,6 +2385,12 @@ class SpanPeakSelector:
         button_row1 = tk.Frame(control_frame)
         button_row1.pack(fill=tk.X, padx=5, pady=2)
 
+        self.analyze_btn = ButtonCls(
+            button_row1,
+            text="Analyze Spectra",
+            command=self.analyze_spectra,
+            **button_kwargs,
+        )
         self.analyse_btn = ButtonCls(
             button_row1,
             text="Analyse FWHM",

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -279,6 +279,23 @@ def test_results_persist_across_analyses():
     plt.close(fig)
 
 
+def test_analyze_spectra_runs_pipeline():
+    spectrum = ESRSpectrum(field=np.arange(5.0), intensity=np.zeros(5))
+    selector = gui.SpanPeakSelector(spectrum)
+
+    with patch.object(selector, "peak_finder") as pf, \
+        patch.object(selector, "start_peak_to_peak") as dhpp, \
+        patch.object(selector, "start_analysis") as fwhm, \
+        patch.object(selector, "fit_lorentzian") as fit, \
+        patch.object(selector, "calculate_g") as gcalc:
+        selector.analyze_spectra()
+        pf.assert_called_once()
+        dhpp.assert_called_once()
+        fwhm.assert_called_once()
+        fit.assert_called_once()
+        gcalc.assert_called_once()
+
+
 def test_multi_trace_results_isolated():
     spec1 = ESRSpectrum(field=np.arange(5.0), intensity=np.zeros(5))
     spec2 = ESRSpectrum(field=np.arange(5.0), intensity=np.ones(5))


### PR DESCRIPTION
## Summary
- Add "Analyze Spectra" button to run peak finding, linewidth, Lorentzian fitting and g-factor calculation sequentially
- Implement analyze_spectra helper combining existing analysis steps
- Document new one-click analysis feature and test pipeline

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf0a93d1948324ae6e64f77c1359f1